### PR TITLE
Baip 222/version 3

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -68,10 +68,15 @@ Required data:
 - default route ID: unsigned integer
 - under test: boolean
 
+Data assigned by API:
+- id: unsigned integer
+- timestamp: unsigned integer
+
 Example:
 ```json
 {
     "id": 12,
+    "timestamp": 1707805396,
     "name": "Car 1",
     "platform_hw_id": 1,
     "car_admin_phone": "123456789",
@@ -95,6 +100,7 @@ Example:
 ```json
 {
     "id": 12,
+    "timestamp": 1707805396,
     "car_id": 1,
     "status": "idle",
     "fuel": 100,
@@ -119,11 +125,16 @@ Required data:
 - route ID: unsigned integer
 - notification phone: Mobile Phone
 
+Data assigned by API:
+- id: unsigned integer
+- timestamp: unsigned integer (time of the order's creation)
+
 Example:
 ```json
 {
     "id": 12,
     "priority": "normal",
+    "timestamp": 1707805396,
     "user_id": 1,
     "notification": "Please deliver the package to the address",
     "target_stop_id": 1,
@@ -138,9 +149,9 @@ Data structure containing attributes of a given Order, that change in time.
 
 Required data:
 - order status: enum, available options = {to_accept, accepted, in_progress, done, cancelled}
-- order ID: unsigned integer
 
 Data assigned by API:
+- order ID: unsigned integer
 - Timestamp: unsigned integer
 
 Example:
@@ -176,6 +187,9 @@ Required data:
 - name: UTF-8 encoded string
 - stop IDs: set of unsigned integers
 
+Data assigned by API:
+- id: unsigned integer
+
 Example:
 ```json
 {
@@ -192,6 +206,10 @@ Route Visualization represent an ordered set of physical locations for visualiza
 Required data:
 - route ID: unsigned integer
 - points: list of GNSSPosition
+- hexcolor: string
+
+Data assigned by API:
+- id: unsigned integer
 
 Example:
 ```json
@@ -222,6 +240,9 @@ Required data:
 - name: UTF-8 encoded string
 - position: [GNSSPosition](#gnss-position)
 - notification phone: [Mobile Phone](#mobile-phone)
+
+Data assigned by API:
+- id: unsigned integer
 
 Example:
 ```json

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -97,15 +97,13 @@ Car State [description](definitions.md#car-state).
 
 More on endpoints [here](entity_manipulations.md#car-state).
 
-## /carstate[?allAvailable=<allAvailable>]
+## /carstate[?since=<timestamp>&wait=<wait>]
 
 ### POST
 
-Add a new state for a car by ID.
+Add a new state for a car by ID. Query parameters are ignored for this method.
 
-Request body format:
-- allAvailable=true: JSON containing list of the Car States.
-- allAvailable=false or unspecified: JSON version of the Car State.
+Request body format: JSON containing a Car State data.
 
 Response codes:
 - 200: Successfully added new Car State.
@@ -114,20 +112,19 @@ Response codes:
 
 ### GET
 
-Finds states of all cars.
+Finds states of all cars with timestamp >= since.
+If the wait=True and no states would be returned, the request will wait for the next relevant state to be added.
+By default, wait=False, since=0.
 
 Response codes:
 - 200: Returning all existing car states.
 
-## /carstate/{carId}[?allAvailable=<allAvailable>]
+## /carstate/{carId}[?since=<timestamp>&wait=<wait>]
 
 ### GET
 
-Finds car states by ID.
-
-Response format:
-- allAvailable=true: JSON containing list of the Car States.
-- allAvailable=false or unspecified: JSON version of the Car State.
+Finds car states for a car with given ID with timestamp >= since.
+Query options since and wait determine the behavior as described in [Wait mechanism documentation](https://docs.google.com/document/d/1DOHSFV2ui8C7Oyrui1sVxadSqaxPjlY3uif-EK2-Uxo)
 
 Response codes:
 - 200: Successfully found a car state.
@@ -140,13 +137,15 @@ Order [description](definitions.md#order).
 
 More on endpoints [here](entity_manipulations.md#order).
 
-## /order
+## /order[?since=<timestamp>]
 
 ### POST
 
 Create a new order.
 
 Request body format: JSON version of the Order.
+
+Query parameters are ignored for this method.
 
 Response codes:
 - 200: Successfully created a new order.
@@ -155,18 +154,31 @@ Response codes:
 
 ### GET
 
-Finds all orders.
+Finds all orders with timestamp >= since. By default, since=0.
+If no such orders are found, empty list is returned, along with response code 200.
 
 Response body format: JSON array of Order objects.
 
 Response codes:
 - 200: Returning all existing orders.
 
-## /order/{orderId}
+## /order/{carId}[?since=<timestamp>]
 
 ### GET
 
-Finds order by ID.
+Finds all orders assigned to a car referenced by car ID with timestamp >= since. By default, since=0.
+
+Response body format: JSON array of Order objects.
+
+Response codes:
+- 200: Returning all existing orders for given Car.
+- 404: Not found. The Car with the given ID does not exist.
+
+## /order/{carId}/{orderId}
+
+### GET
+
+Finds order by car ID and order ID.
 
 Response format: JSON version of the Order.
 
@@ -184,19 +196,6 @@ Response codes:
 - 400: Bad request. The orderId is not a valid integer.
 - 404: Not found. The Order with the given ID does not exist.
 
-## /order/wait/{carId}
-
-### GET
-
-Get an order by car ID only if it has changed.
-
-Response format: JSON version of the Order.
-
-Response codes:
-- 200: Successfully received a new order.
-- 400: Bad request. The carId is not a valid integer.
-- 404: Not found. The Car with the given ID does not exist.
-
 # Order State endpoints
 
 Order State [description](definitions.md#order-state).
@@ -211,7 +210,7 @@ Create a new order state.
 
 Request body format: JSON version of the OrderState.
 
-Query options since and wait determine the behavior as described in [Wait mechanism documentation](https://docs.google.com/document/d/1DOHSFV2ui8C7Oyrui1sVxadSqaxPjlY3uif-EK2-Uxo)
+Query parameters are ignored for this method.
 
 Response codes:
 - 200: Successfully added new order state.
@@ -223,6 +222,8 @@ Response codes:
 Finds states of all Orders.
 
 Response body format: JSON array of OrderState objects.
+
+Query options since and wait determine the behavior as described in [Wait mechanism documentation](https://docs.google.com/document/d/1DOHSFV2ui8C7Oyrui1sVxadSqaxPjlY3uif-EK2-Uxo)
 
 Response codes:
 - 200: Returning all existing order states.

--- a/docs/entity_manipulations.md
+++ b/docs/entity_manipulations.md
@@ -49,9 +49,11 @@ Requirements:
 - The referenced [Car](#car) must exist.
 
 Result:
-- The Car State is automatically set by the server.
+- The Car State ID is automatically set by the server.
+- The Car State's timestamp is set to match the time it was posted.
 - A Car State is created.
 - Oldest Car States might be deleted, so the number of states stored by the API for the particular [Car](#car) is not greater than $N_{car\,states}$.
+- All the Clients waiting for some new Car States of a particular [Car](#car) receive a response (for the order state GET method).
 
 
 ## Order
@@ -67,6 +69,7 @@ Requirements:
 
 Result:
 - The Order ID is automatically set by the server.
+- The Order's timestamp is set to match the time it was posted.
 - An Order is created.
 - An [Order State](#order-state) created with the `to_accept` status.
 
@@ -94,7 +97,7 @@ Requirements:
 Result:
 - The Order State ID is automatically set by the server.
 - An Order State is created.
-- The Order State's timestamp is updated to match the time it was posted.
+- The Order State's timestamp is set to match the time it was posted.
 - Oldest Order States might be deleted, so the number of states stored by the API for a particular [Order](#order) is not greater than $N_{order\,states}$.
 - All the Clients waiting for some new Order States of a particular [Order](#order) receive a response (for the order state GET method).
 

--- a/fleet_management_api/api_impl/controllers/order.py
+++ b/fleet_management_api/api_impl/controllers/order.py
@@ -78,6 +78,18 @@ def get_order(order_id: int) -> _api.Response:
         return _api.json_response(200, _api.order_from_db_model(order_db_models[0]))
 
 
+def get_car_orders(car_id: int) -> _api.Response:
+    """Get all orders for a given car."""
+    if not _car_exist(car_id):
+        return _api.log_and_respond(404, f"Car with ID={car_id} does not exist.")
+    order_db_models = _db_access.get(
+        _db_models.OrderDBModel, criteria={"car_id": lambda x: x == car_id}
+    )
+    orders = [_api.order_from_db_model(order_db_model) for order_db_model in order_db_models]
+    _api.log_info(f"Returning {len(orders)} orders for car with ID={car_id}.")
+    return _api.json_response(200, orders)
+
+
 def get_updated_orders(car_id: int) -> _api.Response:
     """Returns all orders for a given car that have been updated since their were last requested.
 

--- a/fleet_management_api/api_impl/controllers/order.py
+++ b/fleet_management_api/api_impl/controllers/order.py
@@ -50,7 +50,7 @@ def create_order() -> _api.Response:
             )
 
 
-def delete_order(order_id: int) -> _api.Response:
+def delete_order(car_id: int, order_id: int) -> _api.Response:
     """Delete an existing order."""
     response = _db_access.delete(_db_models.OrderDBModel, order_id)
     if response.status_code == 200:
@@ -63,62 +63,51 @@ def delete_order(order_id: int) -> _api.Response:
         return _api.text_response(response.status_code, msg)
 
 
-def get_order(order_id: int) -> _api.Response:
+def get_order(car_id: int, order_id: int, since: int = 0) -> _api.Response:
     """Get an existing order."""
-    order_db_models = _db_access.get(
-        _db_models.OrderDBModel, criteria={"id": lambda x: x == order_id}
+    order_db_models = _db_access.get_children(
+        parent_base=_db_models.CarDBModel,
+        parent_id=car_id,
+        children_col_name="orders",
+        criteria={
+            "id": lambda x: x == order_id,
+            "timestamp": lambda z: z >= since
+        }
     )
     if len(order_db_models) == 0:
-        msg = f"Order with ID={order_id} was not found."
+        msg = f"Order with ID={order_id} assigned to car with ID={car_id} was not found."
         _api.log_error(msg)
         return _api.text_response(404, msg)
     else:
-        msg = f"Found order with ID={order_id}"
+        msg = f"Found order with ID={order_id} of car with ID={car_id}."
         _api.log_info(msg)
         return _api.json_response(200, _api.order_from_db_model(order_db_models[0]))
 
 
-def get_car_orders(car_id: int) -> _api.Response:
+def get_car_orders(car_id: int, since: int = 0) -> _api.Response:
     """Get all orders for a given car."""
     if not _car_exist(car_id):
         return _api.log_and_respond(404, f"Car with ID={car_id} does not exist.")
-    order_db_models = _db_access.get(
-        _db_models.OrderDBModel, criteria={"car_id": lambda x: x == car_id}
+    order_db_models = _db_access.get_children(
+        parent_base=_db_models.CarDBModel,
+        parent_id=car_id,
+        children_col_name="orders",
+        criteria={"timestamp": lambda z: z >= since}
     )
     orders = [_api.order_from_db_model(order_db_model) for order_db_model in order_db_models]
     _api.log_info(f"Returning {len(orders)} orders for car with ID={car_id}.")
     return _api.json_response(200, orders)
 
 
-def get_updated_orders(car_id: int) -> _api.Response:
-    """Returns all orders for a given car that have been updated since their were last requested.
-
-    After the order have been returned from the API, they are not longer considered updated.
-    """
-    if not _car_exist(car_id):
-        return _api.log_and_respond(404, f"Car with ID={car_id} does not exist.")
-    order_db_models: list[_db_models.OrderDBModel] = _db_access.get(
-        _db_models.OrderDBModel,
-        criteria={"car_id": lambda x: x == car_id, "updated": lambda x: x == True},
-    )
-    for m in order_db_models:
-        m.updated = False
-        response = _db_access.update(m)
-        if response.status_code != 200:
-            return _api.log_and_respond(
-                response.status_code, f"Error when updating order (ID={m.id}). {response.body}"
-            )
-    orders = [_api.order_from_db_model(order_db_model) for order_db_model in order_db_models]
-    _api.log_info(f"Returning {len(orders)} updated orders for car with ID={car_id}.")
-    return _api.json_response(200, orders)
-
-
-def get_orders() -> _api.Response:
+def get_orders(since: int = 0) -> _api.Response:
     """Get all existing orders."""
     _api.log_info("Listing all existing orders.")
     body = [
         _api.order_from_db_model(order_db_model)
-        for order_db_model in _db_access.get(_db_models.OrderDBModel)
+        for order_db_model in _db_access.get(
+            _db_models.OrderDBModel,
+            criteria={"timestamp": lambda x: x >= since}
+        )
     ]
     return _api.json_response(200, body)
 

--- a/fleet_management_api/api_impl/obj_to_db.py
+++ b/fleet_management_api/api_impl/obj_to_db.py
@@ -30,7 +30,7 @@ def car_state_to_db_model(car_state: _models.CarState) -> _db_models.CarStateDBM
         car_position = None
     else:
         car_position = car_state.position.to_dict()
-    timestamp = timestamp = _tstamp.timestamp_ms()
+    timestamp = _tstamp.timestamp_ms()
     return _db_models.CarStateDBModel(
         id=car_state.id,
         status=str(car_state.status),
@@ -51,6 +51,7 @@ def car_state_from_db_model(
         car_position = _models.GNSSPosition.from_dict(car_state_db_model.position)
     return _models.CarState(
         id=car_state_db_model.id,
+        timestamp=car_state_db_model.timestamp,
         status=car_state_db_model.status,
         car_id=car_state_db_model.car_id,
         speed=car_state_db_model.speed,

--- a/fleet_management_api/api_impl/obj_to_db.py
+++ b/fleet_management_api/api_impl/obj_to_db.py
@@ -67,6 +67,7 @@ def order_to_db_model(order: _models.Order) -> _db_models.OrderDBModel:
         notification_phone = order.notification_phone.to_dict()
     return _db_models.OrderDBModel(
         id=order.id,
+        timestamp=_tstamp.timestamp_ms(),
         priority=order.priority,
         user_id=order.user_id,
         car_id=order.car_id,
@@ -84,6 +85,7 @@ def order_from_db_model(order_db_model: _db_models.OrderDBModel) -> _models.Orde
         notification_phone = _models.MobilePhone.from_dict(order_db_model.notification_phone)
     return _models.Order(
         id=order_db_model.id,
+        timestamp=order_db_model.timestamp,
         priority=order_db_model.priority,
         user_id=order_db_model.user_id,
         car_id=order_db_model.car_id,

--- a/fleet_management_api/controllers/car_state_controller.py
+++ b/fleet_management_api/controllers/car_state_controller.py
@@ -28,9 +28,9 @@ def get_all_car_states(wait=None, since=None):  # noqa: E501
 
      # noqa: E501
 
-    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
+    :param wait: Applies to GET methods when no objects would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next object to be created and then returns it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
     :type wait: bool
-    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
 
     :rtype: Union[List[CarState], Tuple[List[CarState], int], Tuple[List[CarState], int, Dict[str, str]]
@@ -38,19 +38,17 @@ def get_all_car_states(wait=None, since=None):  # noqa: E501
     return 'do some magic!'
 
 
-def get_car_states(car_id, wait=None, since=None, all_available=None):  # noqa: E501
+def get_car_states(car_id, wait=None, since=None):  # noqa: E501
     """Find one or all Car States for a Car with given ID.
 
      # noqa: E501
 
     :param car_id: ID of the Car for which to find the Car States.
     :type car_id: int
-    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
+    :param wait: Applies to GET methods when no objects would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next object to be created and then returns it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
     :type wait: bool
-    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
-    :param all_available: Whether to return all available car states or only the latest one
-    :type all_available: bool
 
     :rtype: Union[List[CarState], Tuple[List[CarState], int], Tuple[List[CarState], int, Dict[str, str]]
     """

--- a/fleet_management_api/controllers/car_state_controller.py
+++ b/fleet_management_api/controllers/car_state_controller.py
@@ -23,24 +23,32 @@ def add_car_state(car_state):  # noqa: E501
     return 'do some magic!'
 
 
-def get_all_car_states():  # noqa: E501
+def get_all_car_states(wait=None, since=None):  # noqa: E501
     """Find one or all Car States for a Car with the specified ID.
 
      # noqa: E501
 
+    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
+    :type wait: bool
+    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :type since: int
 
     :rtype: Union[List[CarState], Tuple[List[CarState], int], Tuple[List[CarState], int, Dict[str, str]]
     """
     return 'do some magic!'
 
 
-def get_car_states(car_id, all_available=None):  # noqa: E501
+def get_car_states(car_id, wait=None, since=None, all_available=None):  # noqa: E501
     """Find one or all Car States for a given Car.
 
      # noqa: E501
 
     :param car_id: ID of the Car for which to find the Car States.
     :type car_id: int
+    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
+    :type wait: bool
+    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :type since: int
     :param all_available: Whether to return all available car states or only the latest one
     :type all_available: bool
 

--- a/fleet_management_api/controllers/car_state_controller.py
+++ b/fleet_management_api/controllers/car_state_controller.py
@@ -24,7 +24,7 @@ def add_car_state(car_state):  # noqa: E501
 
 
 def get_all_car_states(wait=None, since=None):  # noqa: E501
-    """Find one or all Car States for a Car with the specified ID.
+    """Find one or all Car States for all existing Cars.
 
      # noqa: E501
 
@@ -39,7 +39,7 @@ def get_all_car_states(wait=None, since=None):  # noqa: E501
 
 
 def get_car_states(car_id, wait=None, since=None, all_available=None):  # noqa: E501
-    """Find one or all Car States for a given Car.
+    """Find one or all Car States for a Car with given ID.
 
      # noqa: E501
 

--- a/fleet_management_api/controllers/order_controller.py
+++ b/fleet_management_api/controllers/order_controller.py
@@ -23,6 +23,21 @@ def create_order(order):  # noqa: E501
     return 'do some magic!'
 
 
+def delete_order(car_id, order_id):  # noqa: E501
+    """Delete an Order identified by its ID and ID of a car to which it is assigned.
+
+     # noqa: E501
+
+    :param car_id: ID of the Car to which the Order is assigned.
+    :type car_id: int
+    :param order_id: ID of the Order to be returned.
+    :type order_id: int
+
+    :rtype: Union[None, Tuple[None, int], Tuple[None, int, Dict[str, str]]
+    """
+    return 'do some magic!'
+
+
 def get_car_orders(car_id, wait=None, since=None):  # noqa: E501
     """Find existing Orders by the corresponding Car ID and return them.
 

--- a/fleet_management_api/controllers/order_controller.py
+++ b/fleet_management_api/controllers/order_controller.py
@@ -38,16 +38,14 @@ def delete_order(car_id, order_id):  # noqa: E501
     return 'do some magic!'
 
 
-def get_car_orders(car_id, wait=None, since=None):  # noqa: E501
+def get_car_orders(car_id, since=None):  # noqa: E501
     """Find existing Orders by the corresponding Car ID and return them.
 
      # noqa: E501
 
     :param car_id: ID of the Car for which Orders shall be returned.
     :type car_id: int
-    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
-    :type wait: bool
-    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
 
     :rtype: Union[Order, Tuple[Order, int], Tuple[Order, int, Dict[str, str]]
@@ -55,7 +53,7 @@ def get_car_orders(car_id, wait=None, since=None):  # noqa: E501
     return 'do some magic!'
 
 
-def get_order(car_id, order_id, wait=None, since=None):  # noqa: E501
+def get_order(car_id, order_id, since=None):  # noqa: E501
     """Find an existing Order by the car ID and the order ID and return it.
 
      # noqa: E501
@@ -64,9 +62,7 @@ def get_order(car_id, order_id, wait=None, since=None):  # noqa: E501
     :type car_id: int
     :param order_id: ID of the Order to be returned.
     :type order_id: int
-    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
-    :type wait: bool
-    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
 
     :rtype: Union[Order, Tuple[Order, int], Tuple[Order, int, Dict[str, str]]
@@ -74,14 +70,12 @@ def get_order(car_id, order_id, wait=None, since=None):  # noqa: E501
     return 'do some magic!'
 
 
-def get_orders(wait=None, since=None):  # noqa: E501
+def get_orders(since=None):  # noqa: E501
     """Find all currently existing Orders.
 
      # noqa: E501
 
-    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
-    :type wait: bool
-    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
 
     :rtype: Union[List[Order], Tuple[List[Order], int], Tuple[List[Order], int, Dict[str, str]]

--- a/fleet_management_api/controllers/order_controller.py
+++ b/fleet_management_api/controllers/order_controller.py
@@ -23,51 +23,52 @@ def create_order(order):  # noqa: E501
     return 'do some magic!'
 
 
-def delete_order(order_id):  # noqa: E501
-    """Delete an Order with the specified ID.
+def get_order(car_id, wait=None, since=None):  # noqa: E501
+    """Find existing Orders by the corresponding Car ID and return them.
 
      # noqa: E501
 
-    :param order_id: ID of the Order to be deleted.
-    :type order_id: int
-
-    :rtype: Union[None, Tuple[None, int], Tuple[None, int, Dict[str, str]]
-    """
-    return 'do some magic!'
-
-
-def get_order(order_id):  # noqa: E501
-    """Find an existing Order by its ID and return it.
-
-     # noqa: E501
-
-    :param order_id: ID of the Order to be returned.
-    :type order_id: int
+    :param car_id: ID of the Car for which Orders shall be returned.
+    :type car_id: int
+    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
+    :type wait: bool
+    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :type since: int
 
     :rtype: Union[Order, Tuple[Order, int], Tuple[Order, int, Dict[str, str]]
     """
     return 'do some magic!'
 
 
-def get_orders():  # noqa: E501
+def get_order_0(car_id, order_id, wait=None, since=None):  # noqa: E501
+    """Find an existing Order by the car ID and the order ID and return it.
+
+     # noqa: E501
+
+    :param car_id: ID of the Car to which the Order is assigned.
+    :type car_id: int
+    :param order_id: ID of the Order to be returned.
+    :type order_id: int
+    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
+    :type wait: bool
+    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :type since: int
+
+    :rtype: Union[Order, Tuple[Order, int], Tuple[Order, int, Dict[str, str]]
+    """
+    return 'do some magic!'
+
+
+def get_orders(wait=None, since=None):  # noqa: E501
     """Find all currently existing Orders.
 
      # noqa: E501
 
+    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
+    :type wait: bool
+    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :type since: int
 
     :rtype: Union[List[Order], Tuple[List[Order], int], Tuple[List[Order], int, Dict[str, str]]
-    """
-    return 'do some magic!'
-
-
-def get_updated_orders(car_id):  # noqa: E501
-    """Get updated Orders for a given Car specified by its ID.
-
-     # noqa: E501
-
-    :param car_id: ID of the Car for which updated Orders are requested.
-    :type car_id: int
-
-    :rtype: Union[Order, Tuple[Order, int], Tuple[Order, int, Dict[str, str]]
     """
     return 'do some magic!'

--- a/fleet_management_api/controllers/order_controller.py
+++ b/fleet_management_api/controllers/order_controller.py
@@ -23,7 +23,7 @@ def create_order(order):  # noqa: E501
     return 'do some magic!'
 
 
-def get_order(car_id, wait=None, since=None):  # noqa: E501
+def get_car_orders(car_id, wait=None, since=None):  # noqa: E501
     """Find existing Orders by the corresponding Car ID and return them.
 
      # noqa: E501
@@ -40,7 +40,7 @@ def get_order(car_id, wait=None, since=None):  # noqa: E501
     return 'do some magic!'
 
 
-def get_order_0(car_id, order_id, wait=None, since=None):  # noqa: E501
+def get_order(car_id, order_id, wait=None, since=None):  # noqa: E501
     """Find an existing Order by the car ID and the order ID and return it.
 
      # noqa: E501

--- a/fleet_management_api/controllers/order_state_controller.py
+++ b/fleet_management_api/controllers/order_state_controller.py
@@ -28,9 +28,9 @@ def get_all_order_states(wait=None, since=None):  # noqa: E501
 
      # noqa: E501
 
-    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
+    :param wait: Applies to GET methods when no objects would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next object to be created and then returns it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
     :type wait: bool
-    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
 
     :rtype: Union[List[OrderState], Tuple[List[OrderState], int], Tuple[List[OrderState], int, Dict[str, str]]
@@ -45,9 +45,9 @@ def get_order_states(order_id, wait=None, since=None):  # noqa: E501
 
     :param order_id: ID of the Order for which to find the Order States.
     :type order_id: int
-    :param wait: Applies to GET methods when no order statuses would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next order state to be created and then return it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
+    :param wait: Applies to GET methods when no objects would be returned at the moment of request. If wait&#x3D;true, \\ the request will wait for the next object to be created and then returns it. If wait&#x3D;False or unspecified, the request will return \\ an empty list.
     :type wait: bool
-    :param since: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified, all states are returned (since is set to 0 in that case).
+    :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
 
     :rtype: Union[List[OrderState], Tuple[List[OrderState], int], Tuple[List[OrderState], int, Dict[str, str]]

--- a/fleet_management_api/controllers/order_state_controller.py
+++ b/fleet_management_api/controllers/order_state_controller.py
@@ -24,7 +24,7 @@ def create_order_state(order_state):  # noqa: E501
 
 
 def get_all_order_states(wait=None, since=None):  # noqa: E501
-    """Find one or all Order States for all existing Orders.
+    """Find Order States for all existing Orders.
 
      # noqa: E501
 

--- a/fleet_management_api/controllers/platform_hw_controller.py
+++ b/fleet_management_api/controllers/platform_hw_controller.py
@@ -24,7 +24,7 @@ def create_hw(platform_hw):  # noqa: E501
 
 
 def delete_hw(platform_hw_id):  # noqa: E501
-    """Delete Platform HW with given ID.
+    """Delete Platform HW with the given ID.
 
      # noqa: E501
 
@@ -37,7 +37,7 @@ def delete_hw(platform_hw_id):  # noqa: E501
 
 
 def get_hw(platform_hw_id):  # noqa: E501
-    """Find Platform HW with given ID.
+    """Find Platform HW with the given ID.
 
      # noqa: E501
 

--- a/fleet_management_api/database/db_models.py
+++ b/fleet_management_api/database/db_models.py
@@ -67,9 +67,7 @@ class CarStateDBModel(Base):
     speed: _Mapped[float] = _mapped_column(_sqa.Float)
     fuel: _Mapped[int] = _mapped_column(_sqa.Integer)
     position: _Mapped[dict] = _mapped_column(_sqa.JSON)
-    timestamp: _Mapped[int] = _mapped_column(
-        _sqa.BigInteger
-    )  # timestamp attribute serves for auto-removal of old states
+    timestamp: _Mapped[int] = _mapped_column(_sqa.BigInteger)
 
     car: _Mapped[CarDBModel] = _relationship("CarDBModel", back_populates="states", lazy="noload")
 
@@ -94,6 +92,7 @@ class OrderDBModel(Base):
     __tablename__ = "orders"
     priority: _Mapped[str] = _mapped_column(_sqa.String)
     user_id: _Mapped[int] = _mapped_column(_sqa.Integer)
+    timestamp: _Mapped[int] = _mapped_column(_sqa.BigInteger)
     target_stop_id: _Mapped[int] = _mapped_column(_sqa.ForeignKey("stops.id"), nullable=False)
     stop_route_id: _Mapped[int] = _mapped_column(_sqa.Integer)
     notification_phone: _Mapped[dict] = _mapped_column(_sqa.JSON)
@@ -112,9 +111,9 @@ class OrderDBModel(Base):
 
     def __repr__(self) -> str:
         return (
-            f"Order(ID={self.id}, priority={self.priority}, user_ID={self.user_id}, car_ID={self.car_id}, "
-            f"target_stop_ID={self.target_stop_id}, stop_route_ID={self.stop_route_id}, "
-            f"notification_phone={self.notification_phone})"
+            f"Order(ID={self.id}, priority={self.priority}, user_ID={self.user_id}, "
+            f"car_ID={self.car_id}, target_stop_ID={self.target_stop_id}, "
+            f"stop_route_ID={self.stop_route_id}, notification_phone={self.notification_phone})"
         )
 
 

--- a/fleet_management_api/models/car_state.py
+++ b/fleet_management_api/models/car_state.py
@@ -98,7 +98,7 @@ class CarState(Model):
     def timestamp(self) -> int:
         """Gets the timestamp of this CarState.
 
-        A Unix timestamp in milliseconds.  # noqa: E501
+        A Unix timestamp in milliseconds. The timestamp is used to determine the time of creation of an object.  # noqa: E501
 
         :return: The timestamp of this CarState.
         :rtype: int
@@ -109,7 +109,7 @@ class CarState(Model):
     def timestamp(self, timestamp: int):
         """Sets the timestamp of this CarState.
 
-        A Unix timestamp in milliseconds.  # noqa: E501
+        A Unix timestamp in milliseconds. The timestamp is used to determine the time of creation of an object.  # noqa: E501
 
         :param timestamp: The timestamp of this CarState.
         :type timestamp: int

--- a/fleet_management_api/models/car_state.py
+++ b/fleet_management_api/models/car_state.py
@@ -16,11 +16,13 @@ class CarState(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, id=None, status=None, fuel=0, car_id=None, speed=0.0, position=None):  # noqa: E501
+    def __init__(self, id=None, timestamp=None, status=None, fuel=0, car_id=None, speed=0.0, position=None):  # noqa: E501
         """CarState - a model defined in OpenAPI
 
         :param id: The id of this CarState.  # noqa: E501
         :type id: int
+        :param timestamp: The timestamp of this CarState.  # noqa: E501
+        :type timestamp: int
         :param status: The status of this CarState.  # noqa: E501
         :type status: CarStatus
         :param fuel: The fuel of this CarState.  # noqa: E501
@@ -34,6 +36,7 @@ class CarState(Model):
         """
         self.openapi_types = {
             'id': int,
+            'timestamp': int,
             'status': CarStatus,
             'fuel': int,
             'car_id': int,
@@ -43,6 +46,7 @@ class CarState(Model):
 
         self.attribute_map = {
             'id': 'id',
+            'timestamp': 'timestamp',
             'status': 'status',
             'fuel': 'fuel',
             'car_id': 'carId',
@@ -51,6 +55,7 @@ class CarState(Model):
         }
 
         self._id = id
+        self._timestamp = timestamp
         self._status = status
         self._fuel = fuel
         self._car_id = car_id
@@ -88,6 +93,29 @@ class CarState(Model):
         """
 
         self._id = id
+
+    @property
+    def timestamp(self) -> int:
+        """Gets the timestamp of this CarState.
+
+        A Unix timestamp in milliseconds.  # noqa: E501
+
+        :return: The timestamp of this CarState.
+        :rtype: int
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp: int):
+        """Sets the timestamp of this CarState.
+
+        A Unix timestamp in milliseconds.  # noqa: E501
+
+        :param timestamp: The timestamp of this CarState.
+        :type timestamp: int
+        """
+
+        self._timestamp = timestamp
 
     @property
     def status(self) -> CarStatus:

--- a/fleet_management_api/models/order.py
+++ b/fleet_management_api/models/order.py
@@ -26,7 +26,7 @@ class Order(Model):
         :param user_id: The user_id of this Order.  # noqa: E501
         :type user_id: int
         :param timestamp: The timestamp of this Order.  # noqa: E501
-        :type timestamp: object
+        :type timestamp: int
         :param car_id: The car_id of this Order.  # noqa: E501
         :type car_id: int
         :param notification: The notification of this Order.  # noqa: E501
@@ -42,7 +42,7 @@ class Order(Model):
             'id': int,
             'priority': str,
             'user_id': int,
-            'timestamp': object,
+            'timestamp': int,
             'car_id': int,
             'notification': str,
             'target_stop_id': int,
@@ -153,22 +153,24 @@ class Order(Model):
         self._user_id = user_id
 
     @property
-    def timestamp(self) -> object:
+    def timestamp(self) -> int:
         """Gets the timestamp of this Order.
 
+        A Unix timestamp in milliseconds. The timestamp is used to determine the time of creation of an object.  # noqa: E501
 
         :return: The timestamp of this Order.
-        :rtype: object
+        :rtype: int
         """
         return self._timestamp
 
     @timestamp.setter
-    def timestamp(self, timestamp: object):
+    def timestamp(self, timestamp: int):
         """Sets the timestamp of this Order.
 
+        A Unix timestamp in milliseconds. The timestamp is used to determine the time of creation of an object.  # noqa: E501
 
         :param timestamp: The timestamp of this Order.
-        :type timestamp: object
+        :type timestamp: int
         """
 
         self._timestamp = timestamp

--- a/fleet_management_api/models/order.py
+++ b/fleet_management_api/models/order.py
@@ -16,7 +16,7 @@ class Order(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, id=None, priority='normal', user_id=None, car_id=None, notification=None, target_stop_id=None, stop_route_id=None, notification_phone=None):  # noqa: E501
+    def __init__(self, id=None, priority='normal', user_id=None, timestamp=None, car_id=None, notification=None, target_stop_id=None, stop_route_id=None, notification_phone=None):  # noqa: E501
         """Order - a model defined in OpenAPI
 
         :param id: The id of this Order.  # noqa: E501
@@ -25,6 +25,8 @@ class Order(Model):
         :type priority: str
         :param user_id: The user_id of this Order.  # noqa: E501
         :type user_id: int
+        :param timestamp: The timestamp of this Order.  # noqa: E501
+        :type timestamp: object
         :param car_id: The car_id of this Order.  # noqa: E501
         :type car_id: int
         :param notification: The notification of this Order.  # noqa: E501
@@ -40,6 +42,7 @@ class Order(Model):
             'id': int,
             'priority': str,
             'user_id': int,
+            'timestamp': object,
             'car_id': int,
             'notification': str,
             'target_stop_id': int,
@@ -51,6 +54,7 @@ class Order(Model):
             'id': 'id',
             'priority': 'priority',
             'user_id': 'userId',
+            'timestamp': 'timestamp',
             'car_id': 'carId',
             'notification': 'notification',
             'target_stop_id': 'targetStopId',
@@ -61,6 +65,7 @@ class Order(Model):
         self._id = id
         self._priority = priority
         self._user_id = user_id
+        self._timestamp = timestamp
         self._car_id = car_id
         self._notification = notification
         self._target_stop_id = target_stop_id
@@ -146,6 +151,27 @@ class Order(Model):
             raise ValueError("Invalid value for `user_id`, must not be `None`")  # noqa: E501
 
         self._user_id = user_id
+
+    @property
+    def timestamp(self) -> object:
+        """Gets the timestamp of this Order.
+
+
+        :return: The timestamp of this Order.
+        :rtype: object
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp: object):
+        """Sets the timestamp of this Order.
+
+
+        :param timestamp: The timestamp of this Order.
+        :type timestamp: object
+        """
+
+        self._timestamp = timestamp
 
     @property
     def car_id(self) -> int:

--- a/fleet_management_api/models/order_state.py
+++ b/fleet_management_api/models/order_state.py
@@ -127,7 +127,7 @@ class OrderState(Model):
     def timestamp(self) -> int:
         """Gets the timestamp of this OrderState.
 
-        A Unix timestamp in milliseconds.  # noqa: E501
+        A Unix timestamp in milliseconds. The timestamp is used to determine the time of creation of an object.  # noqa: E501
 
         :return: The timestamp of this OrderState.
         :rtype: int
@@ -138,7 +138,7 @@ class OrderState(Model):
     def timestamp(self, timestamp: int):
         """Sets the timestamp of this OrderState.
 
-        A Unix timestamp in milliseconds.  # noqa: E501
+        A Unix timestamp in milliseconds. The timestamp is used to determine the time of creation of an object.  # noqa: E501
 
         :param timestamp: The timestamp of this OrderState.
         :type timestamp: int

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -494,7 +494,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unexpected error
-      summary: Find one or all Car States for a Car with the specified ID.
+      summary: Find one or all Car States for all existing Cars.
       tags:
       - carState
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.car_state
@@ -652,7 +652,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unexpected error
-      summary: Find one or all Car States for a given Car.
+      summary: Find one or all Car States for a Car with given ID.
       tags:
       - carState
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.car_state

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -909,6 +909,101 @@ paths:
       - order
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
   /order/{carId}/{orderId}:
+    delete:
+      operationId: delete_order
+      parameters:
+      - description: ID of the Car to which the Order is assigned.
+        example: 1
+        in: path
+        name: carId
+        required: true
+        schema:
+          format: int32
+          type: integer
+      - description: ID of the Order to be returned.
+        example: 1
+        in: path
+        name: orderId
+        required: true
+        schema:
+          format: int32
+          type: integer
+      responses:
+        "200":
+          content:
+            text/plain: {}
+          description: The Order with the specified ID has been successfully deleted.
+        "400":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    code: "400"
+                    message: Bad request
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    code: "401"
+                    message: Unauthorized
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    code: "403"
+                    message: Request forbidden
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    code: "404"
+                    message: Resource not found
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Not found
+        "405":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    code: "405"
+                    message: Method not allowed
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Method not allowed
+        default:
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    code: "500"
+                    message: Unexpected error
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unexpected error
+      summary: Delete an Order identified by its ID and ID of a car to which it is
+        assigned.
+      tags:
+      - order
+      x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
     get:
       operationId: get_order
       parameters:

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -813,7 +813,7 @@ paths:
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
   /order/{carId}:
     get:
-      operationId: get_order
+      operationId: get_car_orders
       parameters:
       - description: "Applies to GET methods when no order statuses would be returned\
           \ at the moment of request. If wait=true, \\ the request will wait for the\

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 1.3.1
+  version: 2.0.0
 servers:
 - url: /v2/management
 security:
@@ -433,6 +433,24 @@ paths:
   /carstate:
     get:
       operationId: get_all_car_states
+      parameters:
+      - description: "Applies to GET methods when no order statuses would be returned\
+          \ at the moment of request. If wait=true, \\ the request will wait for the\
+          \ next order state to be created and then return it. If wait=False or unspecified,\
+          \ the request will return \\ an empty list."
+        in: query
+        name: wait
+        schema:
+          default: false
+          type: boolean
+      - description: "A Unix timestamp in milliseconds. If specified, only states\
+          \ created at the time or later will be returned. If unspecified, all states\
+          \ are returned (since is set to 0 in that case)."
+        in: query
+        name: since
+        schema:
+          format: int64
+          type: integer
       responses:
         "200":
           content:
@@ -547,6 +565,23 @@ paths:
     get:
       operationId: get_car_states
       parameters:
+      - description: "Applies to GET methods when no order statuses would be returned\
+          \ at the moment of request. If wait=true, \\ the request will wait for the\
+          \ next order state to be created and then return it. If wait=False or unspecified,\
+          \ the request will return \\ an empty list."
+        in: query
+        name: wait
+        schema:
+          default: false
+          type: boolean
+      - description: "A Unix timestamp in milliseconds. If specified, only states\
+          \ created at the time or later will be returned. If unspecified, all states\
+          \ are returned (since is set to 0 in that case)."
+        in: query
+        name: since
+        schema:
+          format: int64
+          type: integer
       - description: ID of the Car for which to find the Car States.
         example: 1
         in: path
@@ -637,6 +672,24 @@ paths:
   /order:
     get:
       operationId: get_orders
+      parameters:
+      - description: "Applies to GET methods when no order statuses would be returned\
+          \ at the moment of request. If wait=true, \\ the request will wait for the\
+          \ next order state to be created and then return it. If wait=False or unspecified,\
+          \ the request will return \\ an empty list."
+        in: query
+        name: wait
+        schema:
+          default: false
+          type: boolean
+      - description: "A Unix timestamp in milliseconds. If specified, only states\
+          \ created at the time or later will be returned. If unspecified, all states\
+          \ are returned (since is set to 0 in that case)."
+        in: query
+        name: since
+        schema:
+          format: int64
+          type: integer
       responses:
         "200":
           content:
@@ -654,7 +707,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/Order'
                 type: array
-          description: All the currently existing Orders have been returned.
+          description: All the currently existing Orders have been sorted by their
+            creation timestamp from the oldest to newest and returned.
         "401":
           content:
             application/json:
@@ -757,11 +811,28 @@ paths:
       tags:
       - order
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
-  /order/wait/{carId}:
+  /order/{carId}:
     get:
-      operationId: get_updated_orders
+      operationId: get_order
       parameters:
-      - description: ID of the Car for which updated Orders are requested.
+      - description: "Applies to GET methods when no order statuses would be returned\
+          \ at the moment of request. If wait=true, \\ the request will wait for the\
+          \ next order state to be created and then return it. If wait=False or unspecified,\
+          \ the request will return \\ an empty list."
+        in: query
+        name: wait
+        schema:
+          default: false
+          type: boolean
+      - description: "A Unix timestamp in milliseconds. If specified, only states\
+          \ created at the time or later will be returned. If unspecified, all states\
+          \ are returned (since is set to 0 in that case)."
+        in: query
+        name: since
+        schema:
+          format: int64
+          type: integer
+      - description: ID of the Car for which Orders shall be returned.
         example: 1
         in: path
         name: carId
@@ -775,7 +846,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
-          description: All the updated Orders for the specified Car have been returned.
+          description: "The Orders assigned to the Car with the given ID have been\
+            \ found, sorted by their creation timestamp from oldest to newest and\
+            \ returned."
         "400":
           content:
             application/json:
@@ -820,17 +893,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Not found
-        "408":
-          content:
-            application/json:
-              examples:
-                error:
-                  value:
-                    code: "408"
-                    message: Request timeout
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Request timeout
         default:
           content:
             application/json:
@@ -842,100 +904,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unexpected error
-      summary: Get updated Orders for a given Car specified by its ID.
+      summary: Find existing Orders by the corresponding Car ID and return them.
       tags:
       - order
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
-  /order/{orderId}:
-    delete:
-      operationId: delete_order
+  /order/{carId}/{orderId}:
+    get:
+      operationId: get_order
       parameters:
-      - description: ID of the Order to be deleted.
+      - description: ID of the Car to which the Order is assigned.
         example: 1
         in: path
-        name: orderId
+        name: carId
         required: true
         schema:
           format: int32
           type: integer
-      responses:
-        "200":
-          content:
-            text/plain: {}
-          description: The Order with the specified ID has been successfully deleted.
-        "400":
-          content:
-            application/json:
-              examples:
-                error:
-                  value:
-                    code: "400"
-                    message: Bad request
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Bad request
-        "401":
-          content:
-            application/json:
-              examples:
-                error:
-                  value:
-                    code: "401"
-                    message: Unauthorized
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unauthorized
-        "403":
-          content:
-            application/json:
-              examples:
-                error:
-                  value:
-                    code: "403"
-                    message: Request forbidden
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Forbidden
-        "404":
-          content:
-            application/json:
-              examples:
-                error:
-                  value:
-                    code: "404"
-                    message: Resource not found
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Not found
-        "405":
-          content:
-            application/json:
-              examples:
-                error:
-                  value:
-                    code: "405"
-                    message: Method not allowed
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Method not allowed
-        default:
-          content:
-            application/json:
-              examples:
-                error:
-                  value:
-                    code: "500"
-                    message: Unexpected error
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
-      summary: Delete an Order with the specified ID.
-      tags:
-      - order
-      x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
-    get:
-      operationId: get_order
-      parameters:
       - description: ID of the Order to be returned.
         example: 1
         in: path
@@ -944,13 +928,31 @@ paths:
         schema:
           format: int32
           type: integer
+      - description: "Applies to GET methods when no order statuses would be returned\
+          \ at the moment of request. If wait=true, \\ the request will wait for the\
+          \ next order state to be created and then return it. If wait=False or unspecified,\
+          \ the request will return \\ an empty list."
+        in: query
+        name: wait
+        schema:
+          default: false
+          type: boolean
+      - description: "A Unix timestamp in milliseconds. If specified, only states\
+          \ created at the time or later will be returned. If unspecified, all states\
+          \ are returned (since is set to 0 in that case)."
+        in: query
+        name: since
+        schema:
+          format: int64
+          type: integer
       responses:
         "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
-          description: The Order with the specified ID has been found and returned.
+          description: The Order with the specified car ID and order ID has been found
+            and returned.
         "400":
           content:
             application/json:
@@ -1006,7 +1008,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unexpected error
-      summary: Find an existing Order by its ID and return it.
+      summary: Find an existing Order by the car ID and the order ID and return it.
       tags:
       - order
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
@@ -1078,7 +1080,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unexpected error
-      summary: Find one or all Order States for all existing Orders.
+      summary: Find Order States for all existing Orders.
       tags:
       - orderState
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order_state
@@ -1098,7 +1100,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrderState'
-          description: The new Order State has been successfully added.
+          description: The new Order State has been successfully posted.
         "400":
           content:
             application/json:
@@ -1195,8 +1197,9 @@ paths:
                 items:
                   $ref: '#/components/schemas/OrderState'
                 type: array
-          description: All the Order States for the Order specified by its ID have
-            been returned.
+          description: "Order States for the Order specified by its ID have been found,\
+            \ sorted by their creation timestamp \\ from the oldest to the newest\
+            \ and returned."
         "400":
           content:
             application/json:
@@ -1445,7 +1448,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unexpected error
-      summary: Delete Platform HW with given ID.
+      summary: Delete Platform HW with the given ID.
       tags:
       - platformHW
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.platform_hw
@@ -1522,7 +1525,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unexpected error
-      summary: Find Platform HW with given ID.
+      summary: Find Platform HW with the given ID.
       tags:
       - platformHW
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.platform_hw
@@ -2584,17 +2587,6 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
       description: Method not allowed
-    RequestTimeout:
-      content:
-        application/json:
-          examples:
-            error:
-              value:
-                code: "408"
-                message: Request timeout
-          schema:
-            $ref: '#/components/schemas/Error'
-      description: Request timeout
   schemas:
     Error:
       description: Error object structure.
@@ -2665,6 +2657,7 @@ components:
           latitude: 49.204117
           longitude: 16.606525
         speed: 20.5
+        timestamp: 1616425200000
         status: idle
         carId: 1
       properties:
@@ -2672,6 +2665,12 @@ components:
           example: 1
           format: int32
           title: id
+          type: integer
+        timestamp:
+          description: A Unix timestamp in milliseconds.
+          example: 1616425200000
+          format: int64
+          title: timestamp
           type: integer
         status:
           $ref: '#/components/schemas/CarStatus'
@@ -2724,6 +2723,7 @@ components:
         id: 1
         priority: normal
         userId: 1
+        timestamp: ""
         carId: 1
       properties:
         id:
@@ -2742,6 +2742,8 @@ components:
           format: int32
           title: id
           type: integer
+        timestamp:
+          title: timestamp
         carId:
           example: 1
           format: int32
@@ -2974,6 +2976,12 @@ components:
           type: string
       title: MobilePhone
       type: object
+    Timestamp:
+      description: A Unix timestamp in milliseconds.
+      example: 1616425200000
+      format: int64
+      title: timestamp
+      type: integer
     GNSSPosition:
       description: GNSSPosition primitive structure.
       example:
@@ -3001,12 +3009,6 @@ components:
           type: number
       title: GNSSPosition
       type: object
-    Timestamp:
-      description: A Unix timestamp in milliseconds.
-      example: 1616425200000
-      format: int64
-      title: timestamp
-      type: integer
   securitySchemes:
     APIKeyAuth:
       description: Authentication using an API key.

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -434,17 +434,17 @@ paths:
     get:
       operationId: get_all_car_states
       parameters:
-      - description: "Applies to GET methods when no order statuses would be returned\
-          \ at the moment of request. If wait=true, \\ the request will wait for the\
-          \ next order state to be created and then return it. If wait=False or unspecified,\
+      - description: "Applies to GET methods when no objects would be returned at\
+          \ the moment of request. If wait=true, \\ the request will wait for the\
+          \ next object to be created and then returns it. If wait=False or unspecified,\
           \ the request will return \\ an empty list."
         in: query
         name: wait
         schema:
           default: false
           type: boolean
-      - description: "A Unix timestamp in milliseconds. If specified, only states\
-          \ created at the time or later will be returned. If unspecified, all states\
+      - description: "A Unix timestamp in milliseconds. If specified, only objects\
+          \ created at the time or later will be returned. If unspecified, all objects\
           \ are returned (since is set to 0 in that case)."
         in: query
         name: since
@@ -565,17 +565,17 @@ paths:
     get:
       operationId: get_car_states
       parameters:
-      - description: "Applies to GET methods when no order statuses would be returned\
-          \ at the moment of request. If wait=true, \\ the request will wait for the\
-          \ next order state to be created and then return it. If wait=False or unspecified,\
+      - description: "Applies to GET methods when no objects would be returned at\
+          \ the moment of request. If wait=true, \\ the request will wait for the\
+          \ next object to be created and then returns it. If wait=False or unspecified,\
           \ the request will return \\ an empty list."
         in: query
         name: wait
         schema:
           default: false
           type: boolean
-      - description: "A Unix timestamp in milliseconds. If specified, only states\
-          \ created at the time or later will be returned. If unspecified, all states\
+      - description: "A Unix timestamp in milliseconds. If specified, only objects\
+          \ created at the time or later will be returned. If unspecified, all objects\
           \ are returned (since is set to 0 in that case)."
         in: query
         name: since
@@ -590,14 +590,6 @@ paths:
         schema:
           format: int32
           type: integer
-      - description: Whether to return all available car states or only the latest
-          one
-        example: true
-        in: query
-        name: allAvailable
-        required: false
-        schema:
-          type: boolean
       responses:
         "200":
           content:
@@ -673,17 +665,8 @@ paths:
     get:
       operationId: get_orders
       parameters:
-      - description: "Applies to GET methods when no order statuses would be returned\
-          \ at the moment of request. If wait=true, \\ the request will wait for the\
-          \ next order state to be created and then return it. If wait=False or unspecified,\
-          \ the request will return \\ an empty list."
-        in: query
-        name: wait
-        schema:
-          default: false
-          type: boolean
-      - description: "A Unix timestamp in milliseconds. If specified, only states\
-          \ created at the time or later will be returned. If unspecified, all states\
+      - description: "A Unix timestamp in milliseconds. If specified, only objects\
+          \ created at the time or later will be returned. If unspecified, all objects\
           \ are returned (since is set to 0 in that case)."
         in: query
         name: since
@@ -815,17 +798,8 @@ paths:
     get:
       operationId: get_car_orders
       parameters:
-      - description: "Applies to GET methods when no order statuses would be returned\
-          \ at the moment of request. If wait=true, \\ the request will wait for the\
-          \ next order state to be created and then return it. If wait=False or unspecified,\
-          \ the request will return \\ an empty list."
-        in: query
-        name: wait
-        schema:
-          default: false
-          type: boolean
-      - description: "A Unix timestamp in milliseconds. If specified, only states\
-          \ created at the time or later will be returned. If unspecified, all states\
+      - description: "A Unix timestamp in milliseconds. If specified, only objects\
+          \ created at the time or later will be returned. If unspecified, all objects\
           \ are returned (since is set to 0 in that case)."
         in: query
         name: since
@@ -1023,17 +997,8 @@ paths:
         schema:
           format: int32
           type: integer
-      - description: "Applies to GET methods when no order statuses would be returned\
-          \ at the moment of request. If wait=true, \\ the request will wait for the\
-          \ next order state to be created and then return it. If wait=False or unspecified,\
-          \ the request will return \\ an empty list."
-        in: query
-        name: wait
-        schema:
-          default: false
-          type: boolean
-      - description: "A Unix timestamp in milliseconds. If specified, only states\
-          \ created at the time or later will be returned. If unspecified, all states\
+      - description: "A Unix timestamp in milliseconds. If specified, only objects\
+          \ created at the time or later will be returned. If unspecified, all objects\
           \ are returned (since is set to 0 in that case)."
         in: query
         name: since
@@ -1111,17 +1076,17 @@ paths:
     get:
       operationId: get_all_order_states
       parameters:
-      - description: "Applies to GET methods when no order statuses would be returned\
-          \ at the moment of request. If wait=true, \\ the request will wait for the\
-          \ next order state to be created and then return it. If wait=False or unspecified,\
+      - description: "Applies to GET methods when no objects would be returned at\
+          \ the moment of request. If wait=true, \\ the request will wait for the\
+          \ next object to be created and then returns it. If wait=False or unspecified,\
           \ the request will return \\ an empty list."
         in: query
         name: wait
         schema:
           default: false
           type: boolean
-      - description: "A Unix timestamp in milliseconds. If specified, only states\
-          \ created at the time or later will be returned. If unspecified, all states\
+      - description: "A Unix timestamp in milliseconds. If specified, only objects\
+          \ created at the time or later will be returned. If unspecified, all objects\
           \ are returned (since is set to 0 in that case)."
         in: query
         name: since
@@ -1267,17 +1232,17 @@ paths:
         schema:
           format: int32
           type: integer
-      - description: "Applies to GET methods when no order statuses would be returned\
-          \ at the moment of request. If wait=true, \\ the request will wait for the\
-          \ next order state to be created and then return it. If wait=False or unspecified,\
+      - description: "Applies to GET methods when no objects would be returned at\
+          \ the moment of request. If wait=true, \\ the request will wait for the\
+          \ next object to be created and then returns it. If wait=False or unspecified,\
           \ the request will return \\ an empty list."
         in: query
         name: wait
         schema:
           default: false
           type: boolean
-      - description: "A Unix timestamp in milliseconds. If specified, only states\
-          \ created at the time or later will be returned. If unspecified, all states\
+      - description: "A Unix timestamp in milliseconds. If specified, only objects\
+          \ created at the time or later will be returned. If unspecified, all objects\
           \ are returned (since is set to 0 in that case)."
         in: query
         name: since
@@ -2577,18 +2542,18 @@ paths:
 components:
   parameters:
     Wait:
-      description: "Applies to GET methods when no order statuses would be returned\
-        \ at the moment of request. If wait=true, \\ the request will wait for the\
-        \ next order state to be created and then return it. If wait=False or unspecified,\
-        \ the request will return \\ an empty list."
+      description: "Applies to GET methods when no objects would be returned at the\
+        \ moment of request. If wait=true, \\ the request will wait for the next object\
+        \ to be created and then returns it. If wait=False or unspecified, the request\
+        \ will return \\ an empty list."
       in: query
       name: wait
       schema:
         default: false
         type: boolean
     Since:
-      description: "A Unix timestamp in milliseconds. If specified, only states created\
-        \ at the time or later will be returned. If unspecified, all states are returned\
+      description: "A Unix timestamp in milliseconds. If specified, only objects created\
+        \ at the time or later will be returned. If unspecified, all objects are returned\
         \ (since is set to 0 in that case)."
       in: query
       name: since
@@ -2762,7 +2727,8 @@ components:
           title: id
           type: integer
         timestamp:
-          description: A Unix timestamp in milliseconds.
+          description: A Unix timestamp in milliseconds. The timestamp is used to
+            determine the time of creation of an object.
           example: 1616425200000
           format: int64
           title: timestamp
@@ -2818,7 +2784,7 @@ components:
         id: 1
         priority: normal
         userId: 1
-        timestamp: ""
+        timestamp: 1616425200000
         carId: 1
       properties:
         id:
@@ -2838,7 +2804,12 @@ components:
           title: id
           type: integer
         timestamp:
+          description: A Unix timestamp in milliseconds. The timestamp is used to
+            determine the time of creation of an object.
+          example: 1616425200000
+          format: int64
           title: timestamp
+          type: integer
         carId:
           example: 1
           format: int32
@@ -2894,7 +2865,8 @@ components:
           title: id
           type: integer
         timestamp:
-          description: A Unix timestamp in milliseconds.
+          description: A Unix timestamp in milliseconds. The timestamp is used to
+            determine the time of creation of an object.
           example: 1616425200000
           format: int64
           title: timestamp
@@ -3072,7 +3044,8 @@ components:
       title: MobilePhone
       type: object
     Timestamp:
-      description: A Unix timestamp in milliseconds.
+      description: A Unix timestamp in milliseconds. The timestamp is used to determine
+        the time of creation of an object.
       example: 1616425200000
       format: int64
       title: timestamp

--- a/openapi/car.yaml
+++ b/openapi/car.yaml
@@ -189,6 +189,9 @@ paths:
           $ref: './errors.yaml#/components/responses/UnexpectedError'
     get:
       operationId: getAllCarStates
+      parameters:
+        - $ref: 'common_models.yaml#/components/parameters/Wait'
+        - $ref: 'common_models.yaml#/components/parameters/Since'
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.car_state
       tags:
         - carState
@@ -217,6 +220,8 @@ paths:
         - carState
       summary: Find one or all Car States for a given Car.
       parameters:
+        - $ref: 'common_models.yaml#/components/parameters/Wait'
+        - $ref: 'common_models.yaml#/components/parameters/Since'
         - name: carId
           in: path
           description: ID of the Car for which to find the Car States.
@@ -285,6 +290,8 @@ components:
       properties:
         id:
           $ref: 'common_models.yaml#/components/schemas/Id'
+        timestamp:
+          $ref: 'common_models.yaml#/components/schemas/Timestamp'
         status:
           $ref: '#/components/schemas/CarStatus'
         fuel:

--- a/openapi/car.yaml
+++ b/openapi/car.yaml
@@ -195,7 +195,7 @@ paths:
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.car_state
       tags:
         - carState
-      summary: Find one or all Car States for a Car with the specified ID.
+      summary: Find one or all Car States for all existing Cars.
       responses:
         '200':
           description: Successfully found all Car States complying with the request parameters.
@@ -218,7 +218,7 @@ paths:
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.car_state
       tags:
         - carState
-      summary: Find one or all Car States for a given Car.
+      summary: Find one or all Car States for a Car with given ID.
       parameters:
         - $ref: 'common_models.yaml#/components/parameters/Wait'
         - $ref: 'common_models.yaml#/components/parameters/Since'

--- a/openapi/car.yaml
+++ b/openapi/car.yaml
@@ -230,13 +230,6 @@ paths:
           schema:
             type: integer
             format: int32
-        - name: allAvailable
-          in: query
-          description: Whether to return all available car states or only the latest one
-          required: false
-          example: true
-          schema:
-            type: boolean
       responses:
         '200':
           description: Successfully found all Car States complying with the request parameters.

--- a/openapi/common_models.yaml
+++ b/openapi/common_models.yaml
@@ -35,3 +35,22 @@ components:
       type: integer
       format: int64
       example: 1616425200000
+
+  parameters:
+    Wait:
+      name: wait
+      description: Applies to GET methods when no order statuses would be returned at the moment of request. If wait=true, \
+        the request will wait for the next order state to be created and then return it. If wait=False or unspecified, the request will return \
+        an empty list.
+      in: query
+      schema:
+        type: boolean
+        default: false
+    Since:
+      name: since
+      description: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified,
+        all states are returned (since is set to 0 in that case).
+      in: query
+      schema:
+        type: integer
+        format: int64

--- a/openapi/common_models.yaml
+++ b/openapi/common_models.yaml
@@ -31,7 +31,7 @@ components:
           type: string
           example: '+420123456789'
     Timestamp:
-      description: A Unix timestamp in milliseconds.
+      description: A Unix timestamp in milliseconds. The timestamp is used to determine the time of creation of an object.
       type: integer
       format: int64
       example: 1616425200000
@@ -39,8 +39,8 @@ components:
   parameters:
     Wait:
       name: wait
-      description: Applies to GET methods when no order statuses would be returned at the moment of request. If wait=true, \
-        the request will wait for the next order state to be created and then return it. If wait=False or unspecified, the request will return \
+      description: Applies to GET methods when no objects would be returned at the moment of request. If wait=true, \
+        the request will wait for the next object to be created and then returns it. If wait=False or unspecified, the request will return \
         an empty list.
       in: query
       schema:
@@ -48,8 +48,8 @@ components:
         default: false
     Since:
       name: since
-      description: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified,
-        all states are returned (since is set to 0 in that case).
+      description: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified,
+        all objects are returned (since is set to 0 in that case).
       in: query
       schema:
         type: integer

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 1.3.1
+  version: 2.0.0
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -53,10 +53,10 @@ paths:
 
   /order:
     $ref: 'order.yaml#/paths/~1order'
-  /order/{orderId}:
-    $ref: 'order.yaml#/paths/~1order~1{orderId}'
-  /order/wait/{carId}:
-    $ref: 'order.yaml#/paths/~1order~1wait~1{carId}'
+  /order/{carId}:
+    $ref: 'order.yaml#/paths/~1order~1{carId}'
+  /order/{carId}/{orderId}:
+    $ref: 'order.yaml#/paths/~1order~1{carId}~1{orderId}'
   /orderstate:
     $ref: 'order.yaml#/paths/~1orderstate'
   /orderstate/{orderId}:

--- a/openapi/order.yaml
+++ b/openapi/order.yaml
@@ -31,13 +31,16 @@ paths:
           $ref: 'errors.yaml#/components/responses/UnexpectedError'
     get:
       operationId: getOrders
+      parameters:
+        - $ref: '#/components/parameters/Wait'
+        - $ref: '#/components/parameters/Since'
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
       tags:
         - order
       summary: Find all currently existing Orders.
       responses:
         '200':
-          description: All the currently existing Orders have been returned.
+          description: All the currently existing Orders have been sorted by their creation timestamp from the oldest to newest and returned.
           content:
             application/json:
               schema:
@@ -62,17 +65,20 @@ paths:
           $ref: 'errors.yaml#/components/responses/Forbidden'
         default:
           $ref: 'errors.yaml#/components/responses/UnexpectedError'
-  /order/{orderId}:
+
+  /order/{carId}:
     get:
       operationId: getOrder
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
       tags:
         - order
-      summary: Find an existing Order by its ID and return it.
+      summary: Find existing Orders by the corresponding Car ID and return them.
       parameters:
-        - name: orderId
+        - $ref: '#/components/parameters/Wait'
+        - $ref: '#/components/parameters/Since'
+        - name: carId
           in: path
-          description: ID of the Order to be returned.
+          description: ID of the Car for which Orders shall be returned.
           required: true
           example: 1
           schema:
@@ -80,7 +86,7 @@ paths:
             format: int32
       responses:
         '200':
-          description: The Order with the specified ID has been found and returned.
+          description: The Orders assigned to the Car with the given ID have been found, sorted by their creation timestamp from oldest to newest and returned.
           content:
             application/json:
               schema:
@@ -95,12 +101,59 @@ paths:
           $ref: 'errors.yaml#/components/responses/NotFound'
         default:
           $ref: 'errors.yaml#/components/responses/UnexpectedError'
-    delete:
+
+  /order/{carId}/{orderId}:
+    parameters:
+    - name: carId
+      in: path
+      description: ID of the Car to which the Order is assigned.
+      required: true
+      example: 1
+      schema:
+        type: integer
+        format: int32
+    - name: orderId
+      in: path
+      description: ID of the Order to be returned.
+      required: true
+      example: 1
+      schema:
+        type: integer
+        format: int32
+
+    get:
+      operationId: getOrder
+      x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
+      tags:
+        - order
+      summary: Find an existing Order by the car ID and the order ID and return it.
+      parameters:
+        - $ref: '#/components/parameters/Wait'
+        - $ref: '#/components/parameters/Since'
+      responses:
+        '200':
+          description: The Order with the specified car ID and order ID has been found and returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          $ref: 'errors.yaml#/components/responses/BadRequest'
+        '401':
+          $ref: 'errors.yaml#/components/responses/Unauthorized'
+        '403':
+          $ref: 'errors.yaml#/components/responses/Forbidden'
+        '404':
+          $ref: 'errors.yaml#/components/responses/NotFound'
+        default:
+          $ref: 'errors.yaml#/components/responses/UnexpectedError'
+
+  delete:
       operationId: deleteOrder
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
       tags:
         - order
-      summary: Delete an Order with the specified ID.
+      summary: Delete an Order identified by its ID and ID of a car to which it is assigned.
       parameters:
         - name: orderId
           in: path
@@ -128,41 +181,7 @@ paths:
           $ref: 'errors.yaml#/components/responses/MethodNotAllowed'
         default:
           $ref: 'errors.yaml#/components/responses/UnexpectedError'
-  /order/wait/{carId}:
-    get:
-      operationId: getUpdatedOrders
-      x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
-      tags:
-        - order
-      summary: Get updated Orders for a given Car specified by its ID.
-      parameters:
-        - name: carId
-          in: path
-          description: ID of the Car for which updated Orders are requested.
-          required: true
-          example: 1
-          schema:
-            type: integer
-            format: int32
-      responses:
-        '200':
-          description: All the updated Orders for the specified Car have been returned.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Order'
-        '400':
-          $ref: 'errors.yaml#/components/responses/BadRequest'
-        '401':
-          $ref: 'errors.yaml#/components/responses/Unauthorized'
-        '403':
-          $ref: 'errors.yaml#/components/responses/Forbidden'
-        '404':
-          $ref: 'errors.yaml#/components/responses/NotFound'
-        '408':
-          $ref: 'errors.yaml#/components/responses/RequestTimeout'
-        default:
-          $ref: 'errors.yaml#/components/responses/UnexpectedError'
+
   /orderstate:
     post:
       operationId: createOrderState
@@ -180,7 +199,7 @@ paths:
         required: true
       responses:
         '200':
-          description: The new Order State has been successfully added.
+          description: The new Order State has been successfully posted.
           content:
             application/json:
               schema:
@@ -200,7 +219,7 @@ paths:
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order_state
       tags:
         - orderState
-      summary: Find one or all Order States for all existing Orders.
+      summary: Find Order States for all existing Orders.
       parameters:
         - $ref: '#/components/parameters/Wait'
         - $ref: '#/components/parameters/Since'
@@ -247,7 +266,8 @@ paths:
         - $ref: '#/components/parameters/Since'
       responses:
         '200':
-          description: All the Order States for the Order specified by its ID have been returned.
+          description: Order States for the Order specified by its ID have been found, sorted by their creation timestamp \
+            from the oldest to the newest and returned.
           content:
             application/json:
               schema:
@@ -280,6 +300,8 @@ components:
           $ref: "#/components/schemas/Priority"
         userId:
           $ref: 'common_models.yaml#/components/schemas/Id'
+        timestamp:
+          $reg: 'common_models.yaml#/components/schemas/Timestamp'
         carId:
           $ref: 'common_models.yaml#/components/schemas/Id'
         notification:

--- a/openapi/order.yaml
+++ b/openapi/order.yaml
@@ -148,30 +148,30 @@ paths:
         default:
           $ref: 'errors.yaml#/components/responses/UnexpectedError'
 
-  delete:
-      operationId: deleteOrder
-      x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
-      tags:
-        - order
-      summary: Delete an Order identified by its ID and ID of a car to which it is assigned.
-      responses:
-        '200':
-          description: The Order with the specified ID has been successfully deleted.
-          content:
-            text/plain:
-              type: string
-        '400':
-          $ref: 'errors.yaml#/components/responses/BadRequest'
-        '401':
-          $ref: 'errors.yaml#/components/responses/Unauthorized'
-        '403':
-          $ref: 'errors.yaml#/components/responses/Forbidden'
-        '404':
-          $ref: 'errors.yaml#/components/responses/NotFound'
-        '405':
-          $ref: 'errors.yaml#/components/responses/MethodNotAllowed'
-        default:
-          $ref: 'errors.yaml#/components/responses/UnexpectedError'
+    delete:
+        operationId: deleteOrder
+        x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
+        tags:
+          - order
+        summary: Delete an Order identified by its ID and ID of a car to which it is assigned.
+        responses:
+          '200':
+            description: The Order with the specified ID has been successfully deleted.
+            content:
+              text/plain:
+                type: string
+          '400':
+            $ref: 'errors.yaml#/components/responses/BadRequest'
+          '401':
+            $ref: 'errors.yaml#/components/responses/Unauthorized'
+          '403':
+            $ref: 'errors.yaml#/components/responses/Forbidden'
+          '404':
+            $ref: 'errors.yaml#/components/responses/NotFound'
+          '405':
+            $ref: 'errors.yaml#/components/responses/MethodNotAllowed'
+          default:
+            $ref: 'errors.yaml#/components/responses/UnexpectedError'
 
   /orderstate:
     post:

--- a/openapi/order.yaml
+++ b/openapi/order.yaml
@@ -32,8 +32,8 @@ paths:
     get:
       operationId: getOrders
       parameters:
-        - $ref: '#/components/parameters/Wait'
-        - $ref: '#/components/parameters/Since'
+        - $ref: 'common_models.yaml#/components/parameters/Wait'
+        - $ref: 'common_models.yaml#/components/parameters/Since'
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
       tags:
         - order
@@ -74,8 +74,8 @@ paths:
         - order
       summary: Find existing Orders by the corresponding Car ID and return them.
       parameters:
-        - $ref: '#/components/parameters/Wait'
-        - $ref: '#/components/parameters/Since'
+        - $ref: 'common_models.yaml#/components/parameters/Wait'
+        - $ref: 'common_models.yaml#/components/parameters/Since'
         - name: carId
           in: path
           description: ID of the Car for which Orders shall be returned.
@@ -128,8 +128,8 @@ paths:
         - order
       summary: Find an existing Order by the car ID and the order ID and return it.
       parameters:
-        - $ref: '#/components/parameters/Wait'
-        - $ref: '#/components/parameters/Since'
+        - $ref: 'common_models.yaml#/components/parameters/Wait'
+        - $ref: 'common_models.yaml#/components/parameters/Since'
       responses:
         '200':
           description: The Order with the specified car ID and order ID has been found and returned.
@@ -154,15 +154,6 @@ paths:
       tags:
         - order
       summary: Delete an Order identified by its ID and ID of a car to which it is assigned.
-      parameters:
-        - name: orderId
-          in: path
-          description: ID of the Order to be deleted.
-          required: true
-          example: 1
-          schema:
-            type: integer
-            format: int32
       responses:
         '200':
           description: The Order with the specified ID has been successfully deleted.
@@ -221,8 +212,8 @@ paths:
         - orderState
       summary: Find Order States for all existing Orders.
       parameters:
-        - $ref: '#/components/parameters/Wait'
-        - $ref: '#/components/parameters/Since'
+        - $ref: 'common_models.yaml#/components/parameters/Wait'
+        - $ref: 'common_models.yaml#/components/parameters/Since'
       responses:
         '200':
           description: Successfully found all Order States complying with the request parameters.
@@ -262,8 +253,8 @@ paths:
           schema:
             type: integer
             format: int32
-        - $ref: '#/components/parameters/Wait'
-        - $ref: '#/components/parameters/Since'
+        - $ref: 'common_models.yaml#/components/parameters/Wait'
+        - $ref: 'common_models.yaml#/components/parameters/Since'
       responses:
         '200':
           description: Order States for the Order specified by its ID have been found, sorted by their creation timestamp \
@@ -345,24 +336,4 @@ components:
       description: Priority (low, normal, high)
       pattern: ^(low|normal|high)$
       default: "normal"
-
-  parameters:
-    Wait:
-      name: wait
-      description: Applies to GET methods when no order statuses would be returned at the moment of request. If wait=true, \
-        the request will wait for the next order state to be created and then return it. If wait=False or unspecified, the request will return \
-        an empty list.
-      in: query
-      schema:
-        type: boolean
-        default: false
-    Since:
-      name: since
-      description: A Unix timestamp in milliseconds. If specified, only states created at the time or later will be returned. If unspecified,
-        all states are returned (since is set to 0 in that case).
-      in: query
-      schema:
-        type: integer
-        format: int64
-
 

--- a/openapi/order.yaml
+++ b/openapi/order.yaml
@@ -68,7 +68,7 @@ paths:
 
   /order/{carId}:
     get:
-      operationId: getOrder
+      operationId: getCarOrders
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
       tags:
         - order

--- a/openapi/order.yaml
+++ b/openapi/order.yaml
@@ -32,7 +32,6 @@ paths:
     get:
       operationId: getOrders
       parameters:
-        - $ref: 'common_models.yaml#/components/parameters/Wait'
         - $ref: 'common_models.yaml#/components/parameters/Since'
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.order
       tags:
@@ -74,7 +73,6 @@ paths:
         - order
       summary: Find existing Orders by the corresponding Car ID and return them.
       parameters:
-        - $ref: 'common_models.yaml#/components/parameters/Wait'
         - $ref: 'common_models.yaml#/components/parameters/Since'
         - name: carId
           in: path
@@ -128,7 +126,6 @@ paths:
         - order
       summary: Find an existing Order by the car ID and the order ID and return it.
       parameters:
-        - $ref: 'common_models.yaml#/components/parameters/Wait'
         - $ref: 'common_models.yaml#/components/parameters/Since'
       responses:
         '200':
@@ -292,7 +289,7 @@ components:
         userId:
           $ref: 'common_models.yaml#/components/schemas/Id'
         timestamp:
-          $reg: 'common_models.yaml#/components/schemas/Timestamp'
+          $ref: 'common_models.yaml#/components/schemas/Timestamp'
         carId:
           $ref: 'common_models.yaml#/components/schemas/Id'
         notification:

--- a/openapi/platform_hw.yaml
+++ b/openapi/platform_hw.yaml
@@ -63,7 +63,7 @@ paths:
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.platform_hw
       tags:
         - platformHW
-      summary: Find Platform HW with given ID.
+      summary: Find Platform HW with the given ID.
       parameters:
         - name: platformHwId
           in: path
@@ -95,7 +95,7 @@ paths:
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.platform_hw
       tags:
         - platformHW
-      summary: Delete Platform HW with given ID.
+      summary: Delete Platform HW with the given ID.
       parameters:
         - name: platformHwId
           in: path

--- a/tests/controllers/car/test_car_state_controller.py
+++ b/tests/controllers/car/test_car_state_controller.py
@@ -184,7 +184,7 @@ class Test_Getting_Car_State_For_Given_Car(unittest.TestCase):
         with self.app.app.test_client() as c:
             c.post("/v2/management/carstate", json=car_state_1)
             c.post("/v2/management/carstate", json=car_state_2)
-            response = c.get("/v2/management/carstate/1?allAvailable=true")
+            response = c.get("/v2/management/carstate/1?since=0")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(len(response.json), 3)
 
@@ -220,7 +220,7 @@ class Test_Maximum_Number_Of_States_Stored(unittest.TestCase):
                 )
                 c.post("/v2/management/carstate", json=car_state)
 
-            response = c.get("/v2/management/carstate/1?allAvailable=true")
+            response = c.get("/v2/management/carstate/1?since=0")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(len(response.json), max_n - 1)
 
@@ -232,7 +232,7 @@ class Test_Maximum_Number_Of_States_Stored(unittest.TestCase):
                 position=test_position,
             )
             c.post("/v2/management/carstate", json=car_state)
-            response = c.get("/v2/management/carstate/1?allAvailable=true")
+            response = c.get("/v2/management/carstate/1?since=0")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(len(response.json), max_n)
 
@@ -244,7 +244,7 @@ class Test_Maximum_Number_Of_States_Stored(unittest.TestCase):
                 position=test_position,
             )
             c.post("/v2/management/carstate", json=newest_state)
-            response = c.get("/v2/management/carstate/1?allAvailable=true")
+            response = c.get("/v2/management/carstate/1?since=0")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(len(response.json), max_n)
             self.assertTrue(isinstance(response.json, list))
@@ -280,10 +280,10 @@ class Test_Maximum_Number_Of_States_Stored(unittest.TestCase):
                 )
                 c.post("/v2/management/carstate", json=car_state)
             self.assertEqual(
-                len(c.get("/v2/management/carstate/1?allAvailable=True").json), max_n
+                len(c.get("/v2/management/carstate/1?since=0").json), max_n
             )
             self.assertEqual(
-                len(c.get("/v2/management/carstate/2?allAvailable=True").json), max_n
+                len(c.get("/v2/management/carstate/2?since=0").json), max_n
             )
 
     def tearDown(self) -> None:
@@ -324,9 +324,9 @@ class Test_List_Of_States_Is_Deleted_If_Car_Is_Deleted(unittest.TestCase):
         with self.app.app.test_client() as c:
             c.post("/v2/management/carstate", json=state_1)
             c.post("/v2/management/carstate", json=state_2)
-            response = c.get("/v2/management/carstate?allAvailable=true")
+            response = c.get("/v2/management/carstate?since=0")
             self.assertEqual(len(response.json), 3)
-            response = c.get("/v2/management/carstate/1?allAvailable=true")
+            response = c.get("/v2/management/carstate/1?since=0")
             self.assertEqual(
                 len(response.json), 3, "Assert car states have been created."
             )

--- a/tests/controllers/car/test_car_state_controller.py
+++ b/tests/controllers/car/test_car_state_controller.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import sys
+from unittest.mock import patch, Mock
 
 sys.path.append(".")
 
@@ -157,9 +158,9 @@ class Test_Getting_Car_State_For_Given_Car(unittest.TestCase):
         with self.app.app.test_client() as c:
             c.post("/v2/management/carstate", json=car_state_1)
             c.post("/v2/management/carstate", json=car_state_2)
-            response = c.get("/v2/management/carstate/1")
+            response = c.get(f"/v2/management/carstate/1")
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(len(response.json), 1)
+            self.assertEqual(len(response.json), 3)
 
     def test_getting_car_state_for_nonexisting_car_returns_code_404(self):
         with self.app.app.test_client() as c:
@@ -172,9 +173,9 @@ class Test_Getting_Car_State_For_Given_Car(unittest.TestCase):
         with self.app.app.test_client() as c:
             c.post("/v2/management/carstate", json=car_state_1)
             c.post("/v2/management/carstate", json=car_state_2)
-            response = c.get("/v2/management/carstate/1?allAvailable=false")
+            response = c.get("/v2/management/carstate/1?")
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(len(response.json), 1)
+            self.assertEqual(len(response.json), 3)
             self.assertEqual(response.json[0]["status"], "out_of_order")
 
     def test_getting_all_car_states(self):
@@ -301,7 +302,8 @@ class Test_List_Of_States_Is_Deleted_If_Car_Is_Deleted(unittest.TestCase):
             car_admin_phone=MobilePhone(phone="123456789")
         )
         with self.app.app.test_client() as c:
-            c.post("/v2/management/car", json=car)
+            response = c.post("/v2/management/car", json=car)
+            assert response.json is not None
 
     def test_car_states_are_deleted_when_car_is_deleted(self):
         state_1 = CarState(
@@ -331,12 +333,70 @@ class Test_List_Of_States_Is_Deleted_If_Car_Is_Deleted(unittest.TestCase):
             c.delete("/v2/management/car/1")
             response = c.get("/v2/management/car/1")
             self.assertEqual(response.status_code, 404, "Assert car has been deleted.")
-            response = c.get("/v2/management/carstate?allAvailable=true")
+            response = c.get("/v2/management/carstate?since=0")
             self.assertEqual(
                 len(response.json), 0, "Assert car states have been deleted."
             )
-            response = c.get("/v2/management/carstate/1?allAvailable=true")
+            response = c.get("/v2/management/carstate/1")
             self.assertEqual(response.status_code, 404)
+
+
+class Test_Filtering_Car_States_By_Timestamp(unittest.TestCase):
+
+    @patch("fleet_management_api.database.timestamp.timestamp_ms")
+    def setUp(self, mocked_timestamp: Mock) -> None:
+        _connection.set_connection_source_test()
+        self.app = _app.get_test_app()
+        create_platform_hws(self.app, 1)
+        car = Car(
+            platform_hw_id=1,
+            name="car1",
+            car_admin_phone=MobilePhone(phone="123456789")
+        )
+        with self.app.app.test_client() as c:
+            mocked_timestamp.return_value = 0
+            response = c.post("/v2/management/car", json=car)
+            assert response.json is not None
+            car_id = response.json["id"]
+
+        state_1 = CarState(
+            status="idle",
+            car_id=car_id,
+            speed=7,
+            fuel=80,
+            position=GNSSPosition(latitude=48.8606111, longitude=2.337644, altitude=50),
+        )
+        state_2 = CarState(
+            status="charging",
+            car_id=car_id,
+            speed=7,
+            fuel=80,
+            position=GNSSPosition(latitude=48.8606111, longitude=2.337644, altitude=50),
+        )
+        with self.app.app.test_client() as c:
+            mocked_timestamp.return_value = 1000
+            c.post("/v2/management/carstate", json=state_1)
+            mocked_timestamp.return_value = 2000
+            c.post("/v2/management/carstate", json=state_2)
+
+    def test_setting_since_to_zero_returns_all_states_of_given_car(self):
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/carstate/1?since=0")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 3)
+
+    def test_setting_since_to_1000_returns_states_created_after_timestamp_1000(self):
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/carstate/1?since=1000")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 2)
+            self.assertEqual(response.json[0]["timestamp"], 1000)
+
+    def test_setting_since_to_3000_returns_empty_list(self):
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/carstate/1?since=3000")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 0)
 
 
 if __name__ == "__main__":  # pragma: no coverage

--- a/tests/controllers/car/test_get_car_state.py
+++ b/tests/controllers/car/test_get_car_state.py
@@ -1,0 +1,230 @@
+import unittest
+from unittest.mock import patch, Mock
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+import sys
+
+sys.path.append(".")
+
+import fleet_management_api.database.connection as _connection
+import fleet_management_api.app as _app
+from fleet_management_api.models import Car, CarState, MobilePhone
+import fleet_management_api.database as database
+from tests.utils.setup_utils import create_platform_hws
+
+
+class Test_Waiting_For_Car_States_To_Be_Sent_Do_API(unittest.TestCase):
+    def setUp(self) -> None:
+        _connection.set_connection_source_test("test_db.db")
+        self.app = _app.get_test_app()
+        create_platform_hws(self.app)
+        car = Car(name="car1", platform_hw_id=1, car_admin_phone=MobilePhone(phone="1234567890"))
+        with self.app.app.test_client() as c:
+            c.post("/v2/management/car", json=car)
+
+    def test_requesting_car_state_without_wait_mechanism_enabled_immediatelly_returns_empty_list_even_if_no_state_was_sent_yet(
+        self,
+    ):
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/carstate")
+            default_state_timestamp = response.json[0]["timestamp"]
+        with self.app.app.test_client() as c:
+            response = c.get(f"/v2/management/carstate?since={default_state_timestamp+1}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json, [])
+
+    def test_waiting_for_car_state_when_no_state_was_sent_yet(self):
+        car_state = CarState(car_id=1, status="in_progress")
+        with self.app.app.test_client() as c:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                future = executor.submit(c.get, "/v2/management/carstate?wait=true&since=0")
+                time.sleep(0.01)
+                executor.submit(c.post, "/v2/management/carstate", json=car_state)
+                response = future.result()
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(len(response.json), 1)
+
+    def test_all_clients_waiting_get_responses_when_state_relevant_for_them_is_sent(self):
+        car_state = CarState(car_id=1, status="in_progress")
+        with self.app.app.test_client() as c:
+            with ThreadPoolExecutor(max_workers=4) as executor:
+                future_1 = executor.submit(c.get, "/v2/management/carstate?wait=true&since=0")
+                future_2 = executor.submit(c.get, "/v2/management/carstate?wait=true&since=0")
+                future_3 = executor.submit(c.get, "/v2/management/carstate?wait=true&since=0")
+                time.sleep(0.01)
+                executor.submit(c.post, "/v2/management/carstate", json=car_state)
+                for fut in [future_1, future_2, future_3]:
+                    response = fut.result()
+                    self.assertEqual(len(response.json), 1)
+
+    def tearDown(self) -> None:  # pragma: no cover
+        if os.path.isfile("test_db.db"):
+            os.remove("test_db.db")
+
+
+class Test_Wait_For_Car_State_For_Given_Car(unittest.TestCase):
+    def setUp(self) -> None:
+        _connection.set_connection_source_test("test_db.db")
+        database.set_content_timeout_ms(1000)
+        self.app = _app.get_test_app()
+        create_platform_hws(self.app, 2)
+        car_1 = Car(
+            id=1, name="car1", platform_hw_id=1, car_admin_phone=MobilePhone(phone="123456789")
+        )
+        car_2 = Car(
+            id=2, name="car2", platform_hw_id=2, car_admin_phone=MobilePhone(phone="987654321")
+        )
+
+        with self.app.app.test_client() as c:
+            response = c.post("/v2/management/car", json=car_1)
+            response = c.post("/v2/management/car", json=car_2)
+            self.assertEqual(response.status_code, 200)
+
+    def test_waiting_for_car_state_for_given_car(self):
+        car_state = CarState(car_id=1, status="idle")
+        with self.app.app.test_client() as c:
+            with ThreadPoolExecutor(max_workers=5) as executor:
+                future = executor.submit(c.get, "/v2/management/carstate?wait=true&since=0")
+                future_1 = executor.submit(c.get, "/v2/management/carstate/1?wait=true&since=0")
+                future_2 = executor.submit(c.get, "/v2/management/carstate/2?wait=true&since=0")
+                time.sleep(0.01)
+                executor.submit(c.post, "/v2/management/carstate", json=car_state)
+
+                response = future.result()
+                self.assertEqual(len(response.json), 2)
+                response = future_1.result()
+                self.assertEqual(len(response.json), 1)
+                response = future_2.result()
+                self.assertEqual(len(response.json), 1)
+
+    def tearDown(self) -> None:  # pragma: no cover
+        if os.path.isfile("test_db.db"):
+            os.remove("test_db.db")
+
+
+class Test_Timeouts(unittest.TestCase):
+    def setUp(self) -> None:
+        _connection.set_connection_source_test("test_db.db")
+        self.app = _app.get_test_app()
+        create_platform_hws(self.app)
+        car = Car(
+            id=1, name="car1", platform_hw_id=1, car_admin_phone=MobilePhone(phone="1234567890")
+        )
+        with self.app.app.test_client() as c:
+            c.post("/v2/management/car", json=car)
+
+    def test_empty_list_is_sent_in_response_to_requests_with_exceeded_timeout(self):
+        database.set_content_timeout_ms(150)
+        car_state = CarState(car_id=1, status="charging")
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/carstate?&since=0")
+            default_state_timestamp = response.json[0]["timestamp"]
+        with self.app.app.test_client() as c:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                # this waiting thread exceeds timeout before posting the state
+                future_1 = executor.submit(
+                    c.get, f"/v2/management/carstate?wait=true&since={default_state_timestamp+1}"
+                )
+                # this waiting thread gets the state before timeout is exceeded
+                time.sleep(0.1)
+                future_2 = executor.submit(
+                    c.get, f"/v2/management/carstate?wait=true&since={default_state_timestamp+1}"
+                )
+                time.sleep(0.1)
+                # this thread posts the state. It is expected that the first waiting thread already exceeded timeout at this point
+                # and the second waiting thread gets the state
+                executor.submit(c.post, "/v2/management/carstate", json=car_state)
+                # first request times out and gets empty list
+                response = future_1.result()
+                self.assertEqual(len(response.json), 0)
+                # second request obtains the content before timeout is exceeded
+                response = future_2.result()
+                self.assertEqual(len(response.json), 1)
+
+    def tearDown(self) -> None:  # pragma: no cover
+        if os.path.isfile("test_db.db"):
+            os.remove("test_db.db")
+
+
+class Test_Filtering_Car_States_By_Since_Parameter(unittest.TestCase):
+    @patch("fleet_management_api.database.timestamp.timestamp_ms")
+    def setUp(self, mock_timestamp_ms: Mock) -> None:
+        _connection.set_connection_source_test("test_db.db")
+        self.app = _app.get_test_app()
+        create_platform_hws(self.app, 2)
+        car_1 = Car(name="car1", platform_hw_id=1, car_admin_phone=MobilePhone(phone="1234567890"))
+        car_2 = Car(name="car2", platform_hw_id=2, car_admin_phone=MobilePhone(phone="9876543210"))
+        mock_timestamp_ms.return_value = 0
+        with self.app.app.test_client() as c:
+            c.post("/v2/management/car", json=car_1)
+            c.post("/v2/management/car", json=car_2)
+
+    @patch("fleet_management_api.database.timestamp.timestamp_ms")
+    def test_filtering_car_states_by_since_parameter(self, mock_timestamp_ms: Mock):
+        car_state_1 = CarState(car_id=1, status="idle")
+        car_state_2 = CarState(car_id=1, status="driving")
+        with self.app.app.test_client() as c:
+            mock_timestamp_ms.return_value = 50
+            c.post("/v2/management/carstate", json=car_state_1)
+            mock_timestamp_ms.return_value = 100
+            c.post("/v2/management/carstate", json=car_state_2)
+            response = c.get("/v2/management/carstate?since=0")
+            self.assertEqual(len(response.json), 4)  # type: ignore
+            response = c.get("/v2/management/carstate?since=60")
+            self.assertEqual(len(response.json), 1)  # type: ignore
+            response = c.get("/v2/management/carstate?since=100")
+            self.assertEqual(len(response.json), 1)  # type: ignore
+            response = c.get("/v2/management/carstate?since=110")
+            self.assertEqual(len(response.json), 0)  # type: ignore
+
+    @patch("fleet_management_api.database.timestamp.timestamp_ms")
+    def test_filtering_car_states_for_specific_car_by_since_parameter(
+        self, mock_timestamp_ms: Mock
+    ):
+        car_state_1 = CarState(car_id=1, status="idle")
+        car_state_2 = CarState(car_id=1, status="driving")
+        car_state_3 = CarState(car_id=2, status="out_of_order")
+        with self.app.app.test_client() as c:
+            mock_timestamp_ms.return_value = 50
+            c.post("/v2/management/carstate", json=car_state_1)
+            mock_timestamp_ms.return_value = 100
+            c.post("/v2/management/carstate", json=car_state_2)
+            mock_timestamp_ms.return_value = 150
+            c.post("/v2/management/carstate", json=car_state_3)
+
+            response = c.get("/v2/management/carstate/1?since=110")
+            self.assertEqual(len(response.json), 0)  # type: ignore
+            response = c.get("/v2/management/carstate/1?since=60")
+            self.assertEqual(len(response.json), 1)  # type: ignore
+
+            response = c.get("/v2/management/carstate/2?since=110")
+            self.assertEqual(len(response.json), 1)  # type: ignore
+            response = c.get("/v2/management/carstate/2?since=160")
+            self.assertEqual(len(response.json), 0)  # type: ignore
+
+    @patch("fleet_management_api.database.timestamp.timestamp_ms")
+    def test_unspecified_since_parameter_yields_the_list_containing_all_the_car_states(
+        self, mock_timestamp_ms: Mock
+    ):
+        car_state_1 = CarState(car_id=1, status="idle")
+        car_state_2 = CarState(car_id=1, status="idle")
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/carstate/1")
+
+            self.assertEqual(len(response.json), 1)  # type: ignore
+            mock_timestamp_ms.return_value = 50
+            c.post("/v2/management/carstate", json=car_state_1)
+            mock_timestamp_ms.return_value = 100
+            c.post("/v2/management/carstate", json=car_state_2)
+
+            states: list[dict] = c.get("/v2/management/carstate/1").json  # type: ignore
+            self.assertEqual(len(states), 3)
+
+    def tearDown(self) -> None:  # pragma: no cover
+        if os.path.isfile("test_db.db"):
+            os.remove("test_db.db")
+
+
+if __name__ == "__main__":
+    unittest.main(buffer=True)

--- a/tests/controllers/order/test_order_state_controller.py
+++ b/tests/controllers/order/test_order_state_controller.py
@@ -172,45 +172,6 @@ class Test_Getting_Order_State_For_Given_Order(unittest.TestCase):
             )
 
 
-class Test_Adding_Order_State_Makes_Order_To_Be_Listed_As_Updated(unittest.TestCase):
-    def setUp(self) -> None:
-        _connection.set_connection_source_test()
-        self.app = _app.get_test_app()
-        create_platform_hws(self.app)
-        create_stops(self.app, 1)
-        create_route(self.app, stop_ids=(1,))
-        car = Car(id=1, name="car1", platform_hw_id=1, car_admin_phone={})
-        order_1 = Order(
-            priority="high",
-            user_id=1,
-            car_id=1,
-            target_stop_id=1,
-            stop_route_id=1,
-            notification_phone={},
-        )
-        order_2 = Order(
-            priority="high",
-            user_id=1,
-            car_id=1,
-            target_stop_id=1,
-            stop_route_id=1,
-            notification_phone={},
-        )
-        with self.app.app.test_client() as c:
-            c.post("/v2/management/car", json=car)
-            c.post("/v2/management/order", json=order_1)
-            c.post("/v2/management/order", json=order_2)
-
-    def test_adding_state_to_existing_order_makes_the_order_to_appear_as_updated(self):
-        order_state = OrderState(status="to_accept", order_id=1)
-        with self.app.app.test_client() as c:
-            c.get("/v2/management/order/wait/1")
-            c.post("/v2/management/orderstate", json=order_state)
-            response = c.get("/v2/management/order/wait/1")
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(len(response.json), 1)
-
-
 class Test_Maximum_Number_Of_States_Stored(unittest.TestCase):
     def setUp(self) -> None:
         _connection.set_connection_source_test()
@@ -336,7 +297,7 @@ class Test_Deleting_Order_States_When_Deleting_Order(unittest.TestCase):
             response = c.get("/v2/management/orderstate/1?since=0")
             self.assertEqual(len(response.json), 3)
 
-            c.delete("/v2/management/order/1")
+            c.delete("/v2/management/order/1/1")
             response = c.get("/v2/management/orderstate/1?since=0")
             self.assertEqual(response.status_code, 404)
 

--- a/tests/controllers/route/test_stop_controller.py
+++ b/tests/controllers/route/test_stop_controller.py
@@ -261,7 +261,7 @@ class Test_Stop_Cannot_Be_Deleted_If_Assigned_To_Order(unittest.TestCase):
             response = c.delete("/v2/management/stop/1")
             self.assertEqual(response.status_code, 400)
 
-            c.delete("/v2/management/order/1")
+            c.delete("/v2/management/order/1/1")
             c.delete("/v2/management/route/1")
             response = c.delete("/v2/management/stop/1")
             self.assertEqual(response.status_code, 200)

--- a/tests/controllers/test_db_models.py
+++ b/tests/controllers/test_db_models.py
@@ -165,13 +165,10 @@ class Test_Creating_Order_DB_Model(unittest.TestCase):
         )
 
     def test_order_converted_to_db_model_and_back_is_unchanged(self):
-        order_in = Order(
-            id=1, user_id=789, car_id=12, target_stop_id=7, stop_route_id=8
-        )
-        order_out = _obj_to_db.order_from_db_model(
-            _obj_to_db.order_to_db_model(order_in)
-        )
+        order_in = Order(id=1, user_id=789, car_id=12, target_stop_id=7, stop_route_id=8)
+        order_out = _obj_to_db.order_from_db_model(_obj_to_db.order_to_db_model(order_in))
         order_in.id = order_out.id
+        order_in.timestamp = order_out.timestamp
         self.assertEqual(order_out, order_in)
 
     def test_order_with_all_attributes_specified_converted_to_db_model_and_back_is_unchanged(
@@ -188,6 +185,8 @@ class Test_Creating_Order_DB_Model(unittest.TestCase):
         order_out = _obj_to_db.order_from_db_model(
             _obj_to_db.order_to_db_model(order_in)
         )
+        order_in.id = order_out.id
+        order_in.timestamp = order_out.timestamp
         self.assertEqual(order_out, order_in)
 
 

--- a/tests/controllers/test_db_models.py
+++ b/tests/controllers/test_db_models.py
@@ -74,6 +74,7 @@ class Test_Creating_Car_State_DB_Model(unittest.TestCase):
             position=GNSSPosition(latitude=48.8606111, longitude=2.337644, altitude=50),
         )
         car_state_db_model = _obj_to_db.car_state_to_db_model(car_state)
+
         self.assertEqual(car_state_db_model.status, car_state.status)
         self.assertEqual(car_state_db_model.car_id, car_state.car_id)
         self.assertEqual(car_state_db_model.speed, car_state.speed)
@@ -91,26 +92,27 @@ class Test_Creating_Car_State_DB_Model(unittest.TestCase):
         self.assertEqual(car_state_db_model.fuel, car_state.fuel)
         self.assertEqual(car_state_db_model.position, car_state.position)
 
-    def test_car_state_converted_to_db_model_and_back_is_unchanged(self):
-        state_in = CarState(status="idle", car_id=1)
-        state_out = _obj_to_db.car_state_from_db_model(
-            _obj_to_db.car_state_to_db_model(state_in)
-        )
+    @patch("fleet_management_api.database.timestamp._get_time_in_ms")
+    def test_car_state_converted_to_db_model_and_back_is_unchanged(self, mock_timestamp_in_ms: Mock):
+        mock_timestamp_in_ms.return_value = 123456
+        state_in = CarState(status="idle", car_id=1, timestamp=123456)
+        state_out = _obj_to_db.car_state_from_db_model(_obj_to_db.car_state_to_db_model(state_in))
         self.assertEqual(state_out, state_in)
 
+    @patch("fleet_management_api.database.timestamp._get_time_in_ms")
     def test_car_state_with_all_attributes_specified_converted_to_db_model_and_back_is_unchanged(
-        self,
+        self, mock_timestamp_in_ms: Mock
     ):
+        mock_timestamp_in_ms.return_value = 123456
         state_in = CarState(
+            timestamp=123456,
             status="idle",
             car_id=1,
             speed=7,
             fuel=8,
             position=GNSSPosition(latitude=48.8606111, longitude=2.337644, altitude=50),
         )
-        state_out = _obj_to_db.car_state_from_db_model(
-            _obj_to_db.car_state_to_db_model(state_in)
-        )
+        state_out = _obj_to_db.car_state_from_db_model(_obj_to_db.car_state_to_db_model(state_in))
         state_in.id = state_out.id
         self.assertEqual(state_out, state_in)
 


### PR DESCRIPTION
Developers of Fleet Management GUI and Integration layer required additional options for filtering and sorting objects retrieved from the Fleet Management server. These included
    - filtering Orders by their creation time (this includes adding timestamp attribute to the Order model),
    - automatic sorting of objects by their timestamp attribute, if they have it (this includes Order, OrderState, and CarState)
    - filtering Orders by car to which they were assigned.

2. To maintain the API as simple as possible, the following has been done
    - removal of the endpoint /order/wait/orderId.


