### PR TITLE
Baip 226/done and canceled as final states

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -76,7 +76,7 @@ Example:
 ```json
 {
     "id": 12,
-    "timestamp": 1707805396,
+    "timestamp": 1707805396152,
     "name": "Car 1",
     "platform_hw_id": 1,
     "car_admin_phone": "123456789",
@@ -100,7 +100,7 @@ Example:
 ```json
 {
     "id": 12,
-    "timestamp": 1707805396,
+    "timestamp": 1707805396753,
     "car_id": 1,
     "status": "idle",
     "fuel": 100,
@@ -134,7 +134,7 @@ Example:
 {
     "id": 12,
     "priority": "normal",
-    "timestamp": 1707805396,
+    "timestamp": 1707805396456,
     "user_id": 1,
     "notification": "Please deliver the package to the address",
     "target_stop_id": 1,
@@ -160,7 +160,7 @@ Example:
     "id": 12,
     "order_id": 1,
     "order_status": "accepted",
-    "timestamp": 1707805396
+    "timestamp": 1707805396123
 }
 ```
 

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -215,6 +215,7 @@ Query parameters are ignored for this method.
 Response codes:
 - 200: Successfully added new order state.
 - 400: Bad request. The request body is not a valid Order State.
+- 403: Forbidden. The Order State cannot be accepted by the API, because the Order has already received State with status DONE or CANCELED.
 - 404: Not found. The Order with the given ID does not exist.
 
 ### GET

--- a/docs/entity_manipulations.md
+++ b/docs/entity_manipulations.md
@@ -96,8 +96,8 @@ Requirements:
 
 Result:
 - The Order State ID is automatically set by the server.
-- An Order State is created.
 - The Order State's timestamp is set to match the time it was posted.
+- An Order State is created IF there is no older Order State with a final status (DONE or CANCELED).
 - Oldest Order States might be deleted, so the number of states stored by the API for a particular [Order](#order) is not greater than $N_{order\,states}$.
 - All the Clients waiting for some new Order States of a particular [Order](#order) receive a response (for the order state GET method).
 

--- a/fleet_management_api/api_impl/controllers/order.py
+++ b/fleet_management_api/api_impl/controllers/order.py
@@ -38,6 +38,7 @@ def create_order() -> _api.Response:
         if response.status_code == 200:
             inserted_model = _api.order_from_db_model(response.body[0])
             _api.log_info(f"Order (ID={inserted_model.id}) has been created.")
+            _add_active_order(inserted_model.id)
             order_state = _models.OrderState(
                 status=_models.OrderStatus.TO_ACCEPT,
                 order_id=inserted_model.id
@@ -114,3 +115,7 @@ def get_orders(since: int = 0) -> _api.Response:
 
 def _car_exist(car_id: int) -> bool:
     return bool(_db_access.get(_db_models.CarDBModel, criteria={"id": lambda x: x == car_id}))
+
+
+def _add_active_order(order_id: int) -> None:
+    _db_models.OrderDBModel.active_orders.add(order_id)

--- a/fleet_management_api/api_impl/controllers/order.py
+++ b/fleet_management_api/api_impl/controllers/order.py
@@ -38,7 +38,6 @@ def create_order() -> _api.Response:
         if response.status_code == 200:
             inserted_model = _api.order_from_db_model(response.body[0])
             _api.log_info(f"Order (ID={inserted_model.id}) has been created.")
-            _add_active_order(inserted_model.id)
             order_state = _models.OrderState(
                 status=_models.OrderStatus.TO_ACCEPT,
                 order_id=inserted_model.id
@@ -115,7 +114,3 @@ def get_orders(since: int = 0) -> _api.Response:
 
 def _car_exist(car_id: int) -> bool:
     return bool(_db_access.get(_db_models.CarDBModel, criteria={"id": lambda x: x == car_id}))
-
-
-def _add_active_order(order_id: int) -> None:
-    _db_models.OrderDBModel.active_orders.add(order_id)

--- a/fleet_management_api/api_impl/controllers/order_state.py
+++ b/fleet_management_api/api_impl/controllers/order_state.py
@@ -15,12 +15,23 @@ _last_order_status: dict[OrderId, _models.OrderStatus] = dict()
 
 
 def initialize_last_order_status_dict() -> None:
+    """Initialize the dictionary that stores the last status of each order.
+
+    The states are primarily stored in the database. The dictionary serves as a cache.
+    If last status is not found in the dictionary when needed, the database is queried.
+
+    This initialization thus does not affect recognizing the order as done or canceled.
+    """
     global _last_order_status
     _last_order_status = dict()
 
 
 def create_order_state() -> _api.Response:
-    """Post a new state of an existing order."""
+    """Post a new state of an existing order.
+
+    If there already exists an Order State with final status (DONE or CANCELED),
+    any other Order State is refused (i.e., 403 is returned).
+    """
     if not _connexion.request.is_json:
         return _api.log_invalid_request_body_format()
     order_state = _models.OrderState.from_dict(_connexion.request.get_json())
@@ -28,7 +39,11 @@ def create_order_state() -> _api.Response:
 
 
 def create_order_state_from_argument(order_state: _models.OrderState) -> _api.Response:
-    """Create a new state of an existing order. The Order State model is passed as an argument."""
+    """Create a new state of an existing order. The Order State model is passed as an argument.
+
+    If there already exists an Order State with final status (DONE or CANCELED),
+    any other Order State is refused (i.e., 403 is returned).
+    """
     if not _order_exists(order_state.order_id):
         return _api.log_and_respond(404, f"Order with id='{order_state.order_id}' was not found.")
 

--- a/fleet_management_api/app.py
+++ b/fleet_management_api/app.py
@@ -8,9 +8,11 @@ from .encoder import JSONEncoder
 import fleet_management_api.database.db_access as _db_access
 from fleet_management_api.database.db_models import ApiKeyDBModel as _ApiKeyDBModel
 from fleet_management_api.database.timestamp import timestamp_ms as _timestamp_ms
+from fleet_management_api.api_impl.controllers.order_state import initialize_last_order_status_dict
 
 
 def get_app() -> connexion.FlaskApp:
+    initialize_last_order_status_dict()
     app = connexion.App(__name__, specification_dir="./openapi/")
     app.app.json_encoder = JSONEncoder
     app.add_api("openapi.yaml", pythonic_params=True)

--- a/fleet_management_api/database/db_models.py
+++ b/fleet_management_api/database/db_models.py
@@ -111,7 +111,6 @@ class OrderDBModel(Base):
         "StopDBModel", back_populates="orders", lazy="noload"
     )
     car: _Mapped["CarDBModel"] = _relationship("CarDBModel", back_populates="orders", lazy="noload")
-    active_orders: set[OrderId] = set()
 
     def __repr__(self) -> str:
         return (

--- a/fleet_management_api/database/db_models.py
+++ b/fleet_management_api/database/db_models.py
@@ -8,6 +8,9 @@ from sqlalchemy.orm import mapped_column as _mapped_column
 from sqlalchemy.orm import relationship as _relationship
 
 
+OrderId = int
+
+
 class Base(_DeclarativeBase):
     model_name: str = "Base"
     id: _Mapped[Optional[int]] = _mapped_column(
@@ -108,6 +111,7 @@ class OrderDBModel(Base):
         "StopDBModel", back_populates="orders", lazy="noload"
     )
     car: _Mapped["CarDBModel"] = _relationship("CarDBModel", back_populates="orders", lazy="noload")
+    active_orders: set[OrderId] = set()
 
     def __repr__(self) -> str:
         return (

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 2.0.2
+  version: 2.1.0
 servers:
 - url: /v2/management
 security:

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 2.0.0
+  version: 2.0.2
 servers:
 - url: /v2/management
 security:
@@ -22,7 +22,7 @@ tags:
   name: car
 - description: Car state-related functions
   name: carState
-- description: Order related functions
+- description: Order-related functions
   name: order
 - description: Order state-related functions
   name: orderState

--- a/openapi/common_models.yaml
+++ b/openapi/common_models.yaml
@@ -34,7 +34,7 @@ components:
       description: A Unix timestamp in milliseconds. The timestamp is used to determine the time of creation of an object.
       type: integer
       format: int64
-      example: 1616425200000
+      example: 1616425275913
 
   parameters:
     Wait:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 2.0.2
+  version: 2.1.0
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 2.0.0
+  version: 2.0.2
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com
@@ -26,7 +26,7 @@ tags:
   - name: carState
     description: Car state-related functions
   - name: order
-    description: Order related functions
+    description: Order-related functions
   - name: orderState
     description: Order state-related functions
   - name: platformHW

--- a/openapi/order.yaml
+++ b/openapi/order.yaml
@@ -52,6 +52,7 @@ paths:
                     "priority": "normal",
                     "userId": 1,
                     "carId": 1,
+                    "timestamp": 1713256508978,
                     "targetStopId": 1,
                     "notification": "Order notification",
                     "stopRouteId": 1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "2.0.2"
+version = "2.1.0"
 
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "2.0.1"
+version = "2.0.2"
 
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
The API now does not accept any more Order States for a given Order if the following Order States were posted:
- Order State with status DONE
- Order State with status CANCELED.

When attempting to post any more states, the API returns a 403 code and an appropriate error message.

Closes BAIP-226.