### PR TITLE
Baf 821/last n states

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -4,4 +4,18 @@ The models used by the API include models with assigned states. Current examples
 - Car and Car State,
 - Order and Order State.
 
-When such an Entity is created, make sure, that an Entity State is automatically created as well!!! For example, when a Car is created, a Car State with status `out_of_order` is created.
+
+When such an Entity is created, make sure, that an Entity State is automatically created as well!!!
+For example, when a Car is created, a Car State with status `out_of_order` is created.
+
+Every state must have (at least) the following attributes:
+- ID of the corresponding Entity
+- timestamp
+
+All GET methods returning object states must have the following filtering options in terms of their corresponding Entity:
+- returning all States for all the existing Entities,
+- returning all States for the particular Entity,
+
+For both of these, further filtering must be available:
+- return only those States inclusively newer than given timestamp,
+- return only up to last N States (with higher timestamp or, if timestamps are equal, with the higher IDs).

--- a/fleet_management_api/api_impl/controllers/car_state.py
+++ b/fleet_management_api/api_impl/controllers/car_state.py
@@ -51,7 +51,15 @@ def add_car_state_from_argument(car_state: _models.CarState) -> _api.Response:
 
 
 def get_all_car_states(since: int = 0, wait: bool = False, last_n: int = 0) -> _api.Response:
-    """Get all car states for all the cars."""
+    """Get all car states for all the cars.
+
+    :param since: Only states with timestamp greater or equal to 'since' will be returned. If 'wait' is True
+        and there are no states with timestamp greater or equal to 'since', the request will wait for new states.
+        Default value is 0.
+
+    :param wait: If True, wait for new states if there are no states yet.
+    :param last_n: If greater than 0, return only up to 'last_n' states with highest timestamp.
+    """
     # first, return car_states with highest timestamp sorted by timestamp and id in descending order
     car_state_db_models = _db_access.get(
         _db_models.CarStateDBModel,
@@ -70,7 +78,15 @@ def get_all_car_states(since: int = 0, wait: bool = False, last_n: int = 0) -> _
 
 
 def get_car_states(car_id: int, since: int = 0, wait: bool = False, last_n: int = 0) -> _api.Response:
-    """Get all car states for a car idenfified by 'car_id' of an existing car."""
+    """Get car states for a car idenfified by 'car_id' of an existing car.
+
+    :param since: Only states with timestamp greater or equal to 'since' will be returned. If 'wait' is True
+        and there are no states with timestamp greater or equal to 'since', the request will wait for new states.
+        Default value is 0.
+
+    :param wait: If True, wait for new states if there are no states yet.
+    :param last_n: If greater than 0, return only up to 'last_n' states with highest timestamp.
+    """
     try:
         car = _db_access.get_by_id(_db_models.CarDBModel, car_id)
         if not car:

--- a/fleet_management_api/api_impl/controllers/order_state.py
+++ b/fleet_management_api/api_impl/controllers/order_state.py
@@ -76,7 +76,15 @@ def create_order_state_from_argument(order_state: _models.OrderState) -> _api.Re
 
 
 def get_all_order_states(wait: bool = False, since: int = 0, last_n: int = 0) -> _api.Response:
-    """Get all order states for all the existing orders."""
+    """Get all order states for all the existing orders.
+
+    :param since: Only states with timestamp greater or equal to 'since' will be returned. If 'wait' is True
+        and there are no states with timestamp greater or equal to 'since', the request will wait for new states.
+        Default value is 0.
+
+    :param wait: If True, wait for new states if there are no states for the order yet.
+    :param last_n: If greater than 0, return only up to 'last_n' states with highest timestamp.
+    """
     _api.log_info("Getting all order states for all orders.")
     return _get_order_states({}, wait, since, last_n=last_n)
 
@@ -86,11 +94,12 @@ def get_order_states(order_id: int, wait: bool = False, since: int = 0, last_n: 
 
     :param order_id: Id of the order.
 
-    :param since: Only statuses with timestamp greater or equal to 'since' will be returned. If 'wait' is True
+    :param since: Only states with timestamp greater or equal to 'since' will be returned. If 'wait' is True
         and there are no states with timestamp greater or equal to 'since', the request will wait for new states.
         Default value is 0.
 
     :param wait: If True, wait for new states if there are no states for the order yet.
+    :param last_n: If greater than 0, return only up to 'last_n' states with highest timestamp.
     """
     if not _order_exists(order_id):
         _api.log_error(f"Order with id='{order_id}' was not found. Cannot get its states.")

--- a/fleet_management_api/controllers/car_state_controller.py
+++ b/fleet_management_api/controllers/car_state_controller.py
@@ -23,7 +23,7 @@ def add_car_state(car_state):  # noqa: E501
     return 'do some magic!'
 
 
-def get_all_car_states(wait=None, since=None):  # noqa: E501
+def get_all_car_states(wait=None, since=None, last_n=None):  # noqa: E501
     """Find one or all Car States for all existing Cars.
 
      # noqa: E501
@@ -32,13 +32,15 @@ def get_all_car_states(wait=None, since=None):  # noqa: E501
     :type wait: bool
     :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
+    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. Minimum value is 1.
+    :type last_n: int
 
     :rtype: Union[List[CarState], Tuple[List[CarState], int], Tuple[List[CarState], int, Dict[str, str]]
     """
     return 'do some magic!'
 
 
-def get_car_states(car_id, wait=None, since=None):  # noqa: E501
+def get_car_states(car_id, wait=None, since=None, last_n=None):  # noqa: E501
     """Find one or all Car States for a Car with given ID.
 
      # noqa: E501
@@ -49,6 +51,8 @@ def get_car_states(car_id, wait=None, since=None):  # noqa: E501
     :type wait: bool
     :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
+    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. Minimum value is 1.
+    :type last_n: int
 
     :rtype: Union[List[CarState], Tuple[List[CarState], int], Tuple[List[CarState], int, Dict[str, str]]
     """

--- a/fleet_management_api/controllers/car_state_controller.py
+++ b/fleet_management_api/controllers/car_state_controller.py
@@ -32,7 +32,7 @@ def get_all_car_states(wait=None, since=None, last_n=None):  # noqa: E501
     :type wait: bool
     :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
-    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. Minimum value is 1.
+    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. If value smaller than 1 is provided, this filtering is ignored.
     :type last_n: int
 
     :rtype: Union[List[CarState], Tuple[List[CarState], int], Tuple[List[CarState], int, Dict[str, str]]
@@ -51,7 +51,7 @@ def get_car_states(car_id, wait=None, since=None, last_n=None):  # noqa: E501
     :type wait: bool
     :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
-    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. Minimum value is 1.
+    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. If value smaller than 1 is provided, this filtering is ignored.
     :type last_n: int
 
     :rtype: Union[List[CarState], Tuple[List[CarState], int], Tuple[List[CarState], int, Dict[str, str]]

--- a/fleet_management_api/controllers/order_state_controller.py
+++ b/fleet_management_api/controllers/order_state_controller.py
@@ -32,7 +32,7 @@ def get_all_order_states(wait=None, since=None, last_n=None):  # noqa: E501
     :type wait: bool
     :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
-    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. Minimum value is 1.
+    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. If value smaller than 1 is provided, this filtering is ignored.
     :type last_n: int
 
     :rtype: Union[List[OrderState], Tuple[List[OrderState], int], Tuple[List[OrderState], int, Dict[str, str]]
@@ -51,7 +51,7 @@ def get_order_states(order_id, wait=None, since=None, last_n=None):  # noqa: E50
     :type wait: bool
     :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
-    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. Minimum value is 1.
+    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. If value smaller than 1 is provided, this filtering is ignored.
     :type last_n: int
 
     :rtype: Union[List[OrderState], Tuple[List[OrderState], int], Tuple[List[OrderState], int, Dict[str, str]]

--- a/fleet_management_api/controllers/order_state_controller.py
+++ b/fleet_management_api/controllers/order_state_controller.py
@@ -23,7 +23,7 @@ def create_order_state(order_state):  # noqa: E501
     return 'do some magic!'
 
 
-def get_all_order_states(wait=None, since=None):  # noqa: E501
+def get_all_order_states(wait=None, since=None, last_n=None):  # noqa: E501
     """Find Order States for all existing Orders.
 
      # noqa: E501
@@ -32,13 +32,15 @@ def get_all_order_states(wait=None, since=None):  # noqa: E501
     :type wait: bool
     :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
+    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. Minimum value is 1.
+    :type last_n: int
 
     :rtype: Union[List[OrderState], Tuple[List[OrderState], int], Tuple[List[OrderState], int, Dict[str, str]]
     """
     return 'do some magic!'
 
 
-def get_order_states(order_id, wait=None, since=None):  # noqa: E501
+def get_order_states(order_id, wait=None, since=None, last_n=None):  # noqa: E501
     """Find all Order States for a particular Order specified by its ID.
 
      # noqa: E501
@@ -49,6 +51,8 @@ def get_order_states(order_id, wait=None, since=None):  # noqa: E501
     :type wait: bool
     :param since: A Unix timestamp in milliseconds. If specified, only objects created at the time or later will be returned. If unspecified, all objects are returned (since is set to 0 in that case).
     :type since: int
+    :param last_n: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \\ If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned. Minimum value is 1.
+    :type last_n: int
 
     :rtype: Union[List[OrderState], Tuple[List[OrderState], int], Tuple[List[OrderState], int, Dict[str, str]]
     """

--- a/fleet_management_api/database/db_access.py
+++ b/fleet_management_api/database/db_access.py
@@ -209,8 +209,14 @@ def get_by_id(
             raise e
 
 
+Order = Literal["asc", "desc"]
+ColumnName = str
+
+
 def get(
     base: type[_Base],
+    first_n: int = 0,
+    sort_result_by: Optional[dict[ColumnName, Order]] = None,
     criteria: Optional[dict[str, Callable[[Any], bool]]] = None,
     wait: bool = False,
     timeout_ms: Optional[int] = None,
@@ -234,6 +240,8 @@ def get(
     global _wait_mg
     if criteria is None:
         criteria = {}
+    if sort_result_by is None:
+        sort_result_by = {}
     table = base.__table__
     source = check_and_return_current_connection_source(connection_source)
     with _Session(source) as session, session.begin():
@@ -242,6 +250,15 @@ def get(
             for attr_label in criteria.keys()
         ]
         stmt = _sqa.select(base).where(*clauses)  # type: ignore
+        for attr_label, order,  in sort_result_by.items():
+            if attr_label in table.columns.keys():
+                if order == "desc":
+                    stmt = stmt.order_by(table.c.__getattr__(attr_label).desc())
+                if order == "asc":
+                    stmt = stmt.order_by(table.c.__getattr__(attr_label).asc())
+
+        if first_n > 0:
+            stmt = stmt.limit(first_n)
         if omitted_relationships is not None:
             for item in omitted_relationships:
                 stmt = stmt.options(_noload(item))

--- a/fleet_management_api/database/db_access.py
+++ b/fleet_management_api/database/db_access.py
@@ -279,7 +279,9 @@ def get_children(
     connection_source: Optional[_sqa.Engine] = None,
     criteria: Optional[dict[str, Callable[[Any], bool]]] = None,
     wait: bool = False,
-    timeout_ms: int = 1000
+    timeout_ms: int = 1000,
+    sort_result_by: Optional[dict[str, Order]] = None,
+    first_n: int = 0
 ) -> list[_Base]:
     """Get children of an instance of an ORM mapped class `parent_base` with `parent_id` from its `children_col_name`.
 

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -454,12 +454,13 @@ paths:
       - description: "If specified, only the last N objects will be returned. If unspecified,\
           \ all objects are returned. \\ If some states have identical timestamps\
           \ and they all do not fit into the maximum N states, only those with higher\
-          \ IDs are returned. Minimum value is 1."
+          \ IDs are returned. If value smaller than 1 is provided, this filtering\
+          \ is ignored."
         in: query
         name: lastN
         schema:
+          default: 0
           format: int32
-          minimum: 1
           type: integer
       responses:
         "200":
@@ -595,12 +596,13 @@ paths:
       - description: "If specified, only the last N objects will be returned. If unspecified,\
           \ all objects are returned. \\ If some states have identical timestamps\
           \ and they all do not fit into the maximum N states, only those with higher\
-          \ IDs are returned. Minimum value is 1."
+          \ IDs are returned. If value smaller than 1 is provided, this filtering\
+          \ is ignored."
         in: query
         name: lastN
         schema:
+          default: 0
           format: int32
-          minimum: 1
           type: integer
       - description: ID of the Car for which to find the Car States.
         example: 1
@@ -1119,12 +1121,13 @@ paths:
       - description: "If specified, only the last N objects will be returned. If unspecified,\
           \ all objects are returned. \\ If some states have identical timestamps\
           \ and they all do not fit into the maximum N states, only those with higher\
-          \ IDs are returned. Minimum value is 1."
+          \ IDs are returned. If value smaller than 1 is provided, this filtering\
+          \ is ignored."
         in: query
         name: lastN
         schema:
+          default: 0
           format: int32
-          minimum: 1
           type: integer
       responses:
         "200":
@@ -1285,12 +1288,13 @@ paths:
       - description: "If specified, only the last N objects will be returned. If unspecified,\
           \ all objects are returned. \\ If some states have identical timestamps\
           \ and they all do not fit into the maximum N states, only those with higher\
-          \ IDs are returned. Minimum value is 1."
+          \ IDs are returned. If value smaller than 1 is provided, this filtering\
+          \ is ignored."
         in: query
         name: lastN
         schema:
+          default: 0
           format: int32
-          minimum: 1
           type: integer
       responses:
         "200":
@@ -2607,12 +2611,12 @@ components:
       description: "If specified, only the last N objects will be returned. If unspecified,\
         \ all objects are returned. \\ If some states have identical timestamps and\
         \ they all do not fit into the maximum N states, only those with higher IDs\
-        \ are returned. Minimum value is 1."
+        \ are returned. If value smaller than 1 is provided, this filtering is ignored."
       in: query
       name: lastN
       schema:
+        default: 0
         format: int32
-        minimum: 1
         type: integer
     RouteId:
       description: An ID a the Route

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 2.1.0
+  version: 2.2.0
 servers:
 - url: /v2/management
 security:
@@ -451,6 +451,16 @@ paths:
         schema:
           format: int64
           type: integer
+      - description: "If specified, only the last N objects will be returned. If unspecified,\
+          \ all objects are returned. \\ If some states have identical timestamps\
+          \ and they all do not fit into the maximum N states, only those with higher\
+          \ IDs are returned. Minimum value is 1."
+        in: query
+        name: lastN
+        schema:
+          format: int32
+          minimum: 1
+          type: integer
       responses:
         "200":
           content:
@@ -582,6 +592,16 @@ paths:
         schema:
           format: int64
           type: integer
+      - description: "If specified, only the last N objects will be returned. If unspecified,\
+          \ all objects are returned. \\ If some states have identical timestamps\
+          \ and they all do not fit into the maximum N states, only those with higher\
+          \ IDs are returned. Minimum value is 1."
+        in: query
+        name: lastN
+        schema:
+          format: int32
+          minimum: 1
+          type: integer
       - description: ID of the Car for which to find the Car States.
         example: 1
         in: path
@@ -681,6 +701,7 @@ paths:
               - priority: normal
                 userId: 1
                 carId: 1
+                timestamp: 1713256508978
                 targetStopId: 1
                 notification: Order notification
                 stopRouteId: 1
@@ -1095,6 +1116,16 @@ paths:
         schema:
           format: int64
           type: integer
+      - description: "If specified, only the last N objects will be returned. If unspecified,\
+          \ all objects are returned. \\ If some states have identical timestamps\
+          \ and they all do not fit into the maximum N states, only those with higher\
+          \ IDs are returned. Minimum value is 1."
+        in: query
+        name: lastN
+        schema:
+          format: int32
+          minimum: 1
+          type: integer
       responses:
         "200":
           content:
@@ -1250,6 +1281,16 @@ paths:
         name: since
         schema:
           format: int64
+          type: integer
+      - description: "If specified, only the last N objects will be returned. If unspecified,\
+          \ all objects are returned. \\ If some states have identical timestamps\
+          \ and they all do not fit into the maximum N states, only those with higher\
+          \ IDs are returned. Minimum value is 1."
+        in: query
+        name: lastN
+        schema:
+          format: int32
+          minimum: 1
           type: integer
       responses:
         "200":
@@ -2562,6 +2603,17 @@ components:
       schema:
         format: int64
         type: integer
+    LastN:
+      description: "If specified, only the last N objects will be returned. If unspecified,\
+        \ all objects are returned. \\ If some states have identical timestamps and\
+        \ they all do not fit into the maximum N states, only those with higher IDs\
+        \ are returned. Minimum value is 1."
+      in: query
+      name: lastN
+      schema:
+        format: int32
+        minimum: 1
+        type: integer
     RouteId:
       description: An ID a the Route
       example: 1
@@ -2719,7 +2771,7 @@ components:
           latitude: 49.204117
           longitude: 16.606525
         speed: 20.5
-        timestamp: 1616425200000
+        timestamp: 1616425275913
         status: idle
         carId: 1
       properties:
@@ -2731,7 +2783,7 @@ components:
         timestamp:
           description: A Unix timestamp in milliseconds. The timestamp is used to
             determine the time of creation of an object.
-          example: 1616425200000
+          example: 1616425275913
           format: int64
           title: timestamp
           type: integer
@@ -2786,7 +2838,7 @@ components:
         id: 1
         priority: normal
         userId: 1
-        timestamp: 1616425200000
+        timestamp: 1616425275913
         carId: 1
       properties:
         id:
@@ -2808,7 +2860,7 @@ components:
         timestamp:
           description: A Unix timestamp in milliseconds. The timestamp is used to
             determine the time of creation of an object.
-          example: 1616425200000
+          example: 1616425275913
           format: int64
           title: timestamp
           type: integer
@@ -2852,7 +2904,7 @@ components:
         orderId: 1
         id: 1
         status: to_accept
-        timestamp: 1616425200000
+        timestamp: 1616425275913
       properties:
         id:
           example: 1
@@ -2869,7 +2921,7 @@ components:
         timestamp:
           description: A Unix timestamp in milliseconds. The timestamp is used to
             determine the time of creation of an object.
-          example: 1616425200000
+          example: 1616425275913
           format: int64
           title: timestamp
           type: integer
@@ -3048,7 +3100,7 @@ components:
     Timestamp:
       description: A Unix timestamp in milliseconds. The timestamp is used to determine
         the time of creation of an object.
-      example: 1616425200000
+      example: 1616425275913
       format: int64
       title: timestamp
       type: integer

--- a/openapi/car.yaml
+++ b/openapi/car.yaml
@@ -192,6 +192,7 @@ paths:
       parameters:
         - $ref: 'common_models.yaml#/components/parameters/Wait'
         - $ref: 'common_models.yaml#/components/parameters/Since'
+        - $ref: 'common_models.yaml#/components/parameters/LastN'
       x-openapi-router-controller: fleet_management_api.api_impl.controllers.car_state
       tags:
         - carState
@@ -222,6 +223,7 @@ paths:
       parameters:
         - $ref: 'common_models.yaml#/components/parameters/Wait'
         - $ref: 'common_models.yaml#/components/parameters/Since'
+        - $ref: 'common_models.yaml#/components/parameters/LastN'
         - name: carId
           in: path
           description: ID of the Car for which to find the Car States.

--- a/openapi/common_models.yaml
+++ b/openapi/common_models.yaml
@@ -58,9 +58,9 @@ components:
       name: lastN
       description: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \
         If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned.
-        Minimum value is 1.
+        If value smaller than 1 is provided, this filtering is ignored.
       in: query
       schema:
         type: integer
         format: int32
-        minimum: 1
+        default: 0

--- a/openapi/common_models.yaml
+++ b/openapi/common_models.yaml
@@ -54,3 +54,13 @@ components:
       schema:
         type: integer
         format: int64
+    LastN:
+      name: lastN
+      description: If specified, only the last N objects will be returned. If unspecified, all objects are returned. \
+        If some states have identical timestamps and they all do not fit into the maximum N states, only those with higher IDs are returned.
+        Minimum value is 1.
+      in: query
+      schema:
+        type: integer
+        format: int32
+        minimum: 1

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 2.1.0
+  version: 2.2.0
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com

--- a/openapi/order.yaml
+++ b/openapi/order.yaml
@@ -214,6 +214,7 @@ paths:
       parameters:
         - $ref: 'common_models.yaml#/components/parameters/Wait'
         - $ref: 'common_models.yaml#/components/parameters/Since'
+        - $ref: 'common_models.yaml#/components/parameters/LastN'
       responses:
         '200':
           description: Successfully found all Order States complying with the request parameters.
@@ -255,6 +256,7 @@ paths:
             format: int32
         - $ref: 'common_models.yaml#/components/parameters/Wait'
         - $ref: 'common_models.yaml#/components/parameters/Since'
+        - $ref: 'common_models.yaml#/components/parameters/LastN'
       responses:
         '200':
           description: Order States for the Order specified by its ID have been found, sorted by their creation timestamp \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "2.1.0"
+version = "2.2.0"
 
 
 [tool.setuptools.packages.find]

--- a/tests/controllers/car/test_car_state_controller.py
+++ b/tests/controllers/car/test_car_state_controller.py
@@ -434,6 +434,97 @@ class Test_Returning_Last_N_Car_States(unittest.TestCase):
             response = c.get("/v2/management/carstate?lastN=1")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(len(response.json), 1)
+            self.assertEqual(response.json[0]["status"], "charging")
+
+    def test_returning_last_2_states(self):
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/carstate?lastN=2")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 2)
+            self.assertEqual(response.json[0]["status"], "idle")
+            self.assertEqual(response.json[1]["status"], "charging")
+
+    def test_setting_last_n_to_higher_value_than_number_of_existing_states_yields_all_existing_states(self):
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/carstate?lastN=100000")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 3)
+            self.assertEqual(response.json[0]["status"], "out_of_order")
+            self.assertEqual(response.json[1]["status"], "idle")
+            self.assertEqual(response.json[2]["status"], "charging")
+
+    def test_returning_last_two_states_newer_than_given_timestamp(self):
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/carstate?lastN=2&since=1500")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 1)
+            self.assertEqual(response.json[0]["status"], "charging")
+
+    def test_returning_last_timestamp_with_identical_timestamps_returns_the_one_with_higher_id(self):
+        state_3 = CarState(status="out_of_order", car_id=1, position=POSITION)
+        with self.app.app.test_client() as c:
+            c.post("/v2/management/carstate", json=state_3)
+            response = c.get("/v2/management/carstate?lastN=1")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 1)
+            self.assertEqual(response.json[0]["status"], "out_of_order")
+
+
+class Test_Returning_Last_N_Car_States_For_Given_Car(unittest.TestCase):
+
+    @patch("fleet_management_api.database.timestamp.timestamp_ms")
+    def setUp(self, mocked_timestamp: Mock) -> None:
+        _connection.set_connection_source_test()
+        self.app = _app.get_test_app()
+        create_platform_hws(self.app, 2)
+        self.car_1 = Car(
+            platform_hw_id=1,
+            name="car1",
+            car_admin_phone=MobilePhone(phone="123456789")
+        )
+        self.car_2 = Car(
+            platform_hw_id=2,
+            name="car2",
+            car_admin_phone=MobilePhone(phone="123456789")
+        )
+        with self.app.app.test_client() as c:
+            mocked_timestamp.return_value = 0
+            self.car_1 = Car.from_dict(c.post("/v2/management/car", json=self.car_1).json)
+            self.car_2 = Car.from_dict(c.post("/v2/management/car", json=self.car_2).json)
+
+        state_1 = CarState(status="idle", car_id=self.car_1.id, position=POSITION)
+        state_2 = CarState(status="charging", car_id=self.car_1.id, position=POSITION)
+        state_3 = CarState(status="idle", car_id=self.car_2.id, position=POSITION)
+        state_4 = CarState(status="driving", car_id=self.car_2.id, position=POSITION)
+
+        with self.app.app.test_client() as c:
+            mocked_timestamp.return_value = 1000
+            c.post("/v2/management/carstate", json=state_1)
+            c.post("/v2/management/carstate", json=state_3)
+            mocked_timestamp.return_value = 2000
+            c.post("/v2/management/carstate", json=state_2)
+            c.post("/v2/management/carstate", json=state_4)
+
+    def test_returning_last_1_state_for_given_car(self):
+        with self.app.app.test_client() as c:
+            response = c.get(f"/v2/management/carstate/{self.car_1.id}?lastN=1")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 1)
+            self.assertEqual(response.json[0]["status"], "charging")
+
+        with self.app.app.test_client() as c:
+            response = c.get(f"/v2/management/carstate/{self.car_2.id}?lastN=1")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 1)
+            self.assertEqual(response.json[0]["status"], "driving")
+
+    def test_returning_last_2_states_for_given_car(self):
+        with self.app.app.test_client() as c:
+            response = c.get(f"/v2/management/carstate/{self.car_1.id}?lastN=2")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 2)
+            self.assertEqual(response.json[0]["status"], "idle")
+            self.assertEqual(response.json[1]["status"], "charging")
 
 
 if __name__ == "__main__":  # pragma: no coverage

--- a/tests/controllers/order/test_order_state_controller.py
+++ b/tests/controllers/order/test_order_state_controller.py
@@ -1,10 +1,11 @@
 import unittest
 import sys
+from unittest.mock import patch, Mock
 
 sys.path.append(".")
 
 import fleet_management_api.app as _app
-from fleet_management_api.models import OrderState, Order, Car, OrderStatus
+from fleet_management_api.models import OrderState, Order, Car, OrderStatus, GNSSPosition, MobilePhone
 import fleet_management_api.database.connection as _connection
 import fleet_management_api.database.db_models as _db_models
 from tests.utils.setup_utils import create_platform_hws, create_stops, create_route
@@ -430,6 +431,141 @@ class Test_Recongnizing_Done_And_Canceled_Orders_After_Restarting_Application(un
             self.assertEqual(response.status_code, 403)
             response = c.get("/v2/management/orderstate/1")
             self.assertEqual(response.json[-1].get("status"), OrderStatus.CANCELED)
+
+
+POSITION = GNSSPosition(latitude=48.8606111, longitude=2.337644, altitude=50)
+PHONE = MobilePhone(phone="123456789")
+
+
+class Test_Returning_Last_N_Order_States(unittest.TestCase):
+
+    @patch("fleet_management_api.database.timestamp.timestamp_ms")
+    def setUp(self, mocked_timestamp: Mock) -> None:
+        _connection.set_connection_source_test()
+        self.app = _app.get_test_app()
+        create_platform_hws(self.app, 1)
+        create_stops(self.app, 1)
+        create_route(self.app, stop_ids=(1,))
+        car = Car(platform_hw_id=1, name="car1", car_admin_phone=PHONE)
+        order = Order(
+            user_id=1, car_id=1, target_stop_id=1, stop_route_id=1, notification_phone=PHONE
+        )
+        with self.app.app.test_client() as c:
+            mocked_timestamp.return_value = 0
+            response = c.post("/v2/management/car", json=car)
+            assert response.json is not None
+            car_id = response.json["id"]
+            order.car_id = car_id
+            response = c.post("/v2/management/order", json=order)
+            assert response.json is not None
+            order_id = response.json["id"]
+
+        state_1 = OrderState(status="accepted", order_id=order_id)
+        state_2 = OrderState(status="in_progress", order_id=order_id)
+
+        with self.app.app.test_client() as c:
+            mocked_timestamp.return_value = 1000
+            c.post("/v2/management/orderstate", json=state_1)
+            mocked_timestamp.return_value = 2000
+            c.post("/v2/management/orderstate", json=state_2)
+
+    def test_returning_last_1_state(self):
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/orderstate?lastN=1")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 1)
+            self.assertEqual(response.json[0]["status"], "in_progress")
+
+    def test_returning_last_2_states(self):
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/orderstate?lastN=2")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 2)
+            self.assertEqual(response.json[0]["status"], "accepted")
+            self.assertEqual(response.json[1]["status"], "in_progress")
+
+    def test_setting_last_n_to_higher_value_than_number_of_existing_states_yields_all_existing_states(self):
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/orderstate?lastN=100000")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 3)
+            self.assertEqual(response.json[0]["status"], "to_accept")
+            self.assertEqual(response.json[1]["status"], "accepted")
+            self.assertEqual(response.json[2]["status"], "in_progress")
+
+    def test_returning_last_two_states_newer_than_given_timestamp(self):
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/orderstate?lastN=2&since=1500")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 1)
+            self.assertEqual(response.json[0]["status"], "in_progress")
+
+    def test_returning_last_timestamp_with_identical_timestamps_returns_the_one_with_higher_id(self):
+        state_3 = OrderState(status="canceled", order_id=1)
+        with self.app.app.test_client() as c:
+            c.post("/v2/management/orderstate", json=state_3)
+            response = c.get("/v2/management/orderstate?lastN=1")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 1)
+            self.assertEqual(response.json[0]["status"], "canceled")
+
+
+class Test_Returning_Last_N_Car_States_For_Given_Car(unittest.TestCase):
+
+    @patch("fleet_management_api.database.timestamp.timestamp_ms")
+    def setUp(self, mocked_timestamp: Mock) -> None:
+        _connection.set_connection_source_test()
+        self.app = _app.get_test_app()
+        create_platform_hws(self.app, 2)
+        create_stops(self.app, 2)
+        create_route(self.app, stop_ids=(1, 2))
+        car_1 = Car(platform_hw_id=1, name="car1", car_admin_phone=PHONE)
+        self.order_1 = Order(
+            user_id=1, car_id=1, target_stop_id=1, stop_route_id=1, notification_phone=PHONE
+        )
+        self.order_2 = Order(
+            user_id=1, car_id=1, target_stop_id=2, stop_route_id=1, notification_phone=PHONE
+        )
+
+        with self.app.app.test_client() as c:
+            mocked_timestamp.return_value = 0
+            c.post("/v2/management/car", json=car_1)
+            c.post("/v2/management/order", json=self.order_1)
+            c.post("/v2/management/order", json=self.order_2)
+
+        state_1 = OrderState(status="accepted", order_id=1)
+        state_2 = OrderState(status="in_progress", order_id=1)
+        state_3 = OrderState(status="accepted", order_id=2)
+        state_4 = OrderState(status="done", order_id=2)
+
+        with self.app.app.test_client() as c:
+            mocked_timestamp.return_value = 1000
+            c.post("/v2/management/orderstate", json=state_1)
+            c.post("/v2/management/orderstate", json=state_3)
+            mocked_timestamp.return_value = 2000
+            c.post("/v2/management/orderstate", json=state_2)
+            c.post("/v2/management/orderstate", json=state_4)
+
+    def test_returning_last_1_state_for_given_car(self):
+        with self.app.app.test_client() as c:
+            response = c.get(f"/v2/management/orderstate/1?lastN=1")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 1)
+            self.assertEqual(response.json[0]["status"], "in_progress")
+
+        with self.app.app.test_client() as c:
+            response = c.get(f"/v2/management/orderstate/2?lastN=1")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 1)
+            self.assertEqual(response.json[0]["status"], "done")
+
+    def test_returning_last_2_states_for_given_car(self):
+        with self.app.app.test_client() as c:
+            response = c.get(f"/v2/management/orderstate/1?lastN=2")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json), 2)
+            self.assertEqual(response.json[0]["status"], "accepted")
+            self.assertEqual(response.json[1]["status"], "in_progress")
 
 
 if __name__ == "__main__":

--- a/tests/database/test_get_last_n.py
+++ b/tests/database/test_get_last_n.py
@@ -1,0 +1,88 @@
+import unittest
+import sys
+import os
+
+sys.path.append(".")
+
+import fleet_management_api.database.connection as _connection
+import fleet_management_api.database.db_access as _db_access
+import tests.database.models as models
+
+
+class Test_Retrieving_Last_N_Records(unittest.TestCase):
+    def setUp(self) -> None:
+        _connection.set_connection_source_test(db_file_path = "tests/database/test_get_last_n.db")
+        models.initialize_test_tables(_connection.current_connection_source())
+
+    def test_retrieving_single_item_with_highest_attribute_value(self):
+        test_obj_1 = models.TestBase(id=7, test_str="test_string", test_int=150)
+        test_obj_2 = models.TestBase(id=8, test_str="test_string", test_int=100)
+        _db_access.add(test_obj_1, test_obj_2)
+        retrieved_objs = _db_access.get(models.TestBase, first_n=1, sort_result_by={"test_int": "desc"})
+        self.assertEqual(len(retrieved_objs), 1)
+        self.assertEqual(retrieved_objs[0].test_int, 150)
+
+    def test_retrieving_both_items_sorted_by_attribute_value_in_descending_order(self):
+        test_obj_1 = models.TestBase(id=7, test_str="test_string", test_int=150)
+        test_obj_2 = models.TestBase(id=8, test_str="test_string", test_int=100)
+        _db_access.add(test_obj_1, test_obj_2)
+        retrieved_objs = _db_access.get(models.TestBase, first_n=2, sort_result_by={"test_int": "desc"})
+        self.assertEqual(retrieved_objs[0].test_int, 150)
+        self.assertEqual(retrieved_objs[1].test_int, 100)
+
+    def test_retrieving_the_two_items_with_highest_attribute_value(self):
+        test_obj_1 = models.TestBase(id=7, test_str="test_string", test_int=150)
+        test_obj_2 = models.TestBase(id=8, test_str="test_string", test_int=100)
+        test_obj_2 = models.TestBase(id=9, test_str="test_string", test_int=120)
+        _db_access.add(test_obj_1, test_obj_2)
+        retrieved_objs = _db_access.get(models.TestBase, first_n=2, sort_result_by={"test_int": "desc"})
+        self.assertEqual(len(retrieved_objs), 2)
+        self.assertEqual(retrieved_objs[0].test_int, 150)
+        self.assertEqual(retrieved_objs[1].test_int, 120)
+
+    def test_retrieving_the_two_items_with_lowest_attribute_value(self):
+        test_obj_1 = models.TestBase(id=7, test_str="test_string", test_int=150)
+        test_obj_2 = models.TestBase(id=8, test_str="test_string", test_int=100)
+        test_obj_3 = models.TestBase(id=9, test_str="test_string", test_int=120)
+        _db_access.add(test_obj_1, test_obj_2, test_obj_3)
+        retrieved_objs = _db_access.get(models.TestBase, first_n=3, sort_result_by={"test_int": "asc"})
+        self.assertEqual(retrieved_objs[0].test_int, 100)
+        self.assertEqual(retrieved_objs[1].test_int, 120)
+
+    def test_returning_items_with_highest_value_of_a_second_attribute_if_first_attribute_values_are_equal(self):
+        test_obj_1 = models.TestBase(test_str="test_string", test_int=100)
+        test_obj_2 = models.TestBase(test_str="test_string", test_int=100)
+        test_obj_3 = models.TestBase(test_str="test_string", test_int=120)
+        _db_access.add(test_obj_1, test_obj_2, test_obj_3)
+        retrieved_objs = _db_access.get(
+            models.TestBase,
+            first_n=2,
+            sort_result_by={"test_int": "desc", "id": "desc"}
+        )
+        self.assertEqual(retrieved_objs[0].test_int, 120)
+        self.assertEqual(retrieved_objs[0].id, 3)
+        self.assertEqual(retrieved_objs[1].test_int, 100)
+        self.assertEqual(retrieved_objs[1].id, 2)
+
+    def test_returning_items_with_lowest_value_of_a_second_attribute_if_first_attribute_values_are_equal(self):
+        test_obj_1 = models.TestBase(test_str="test_string", test_int=100)
+        test_obj_2 = models.TestBase(test_str="test_string", test_int=100)
+        test_obj_3 = models.TestBase(test_str="test_string", test_int=120)
+        _db_access.add(test_obj_1, test_obj_2, test_obj_3)
+        retrieved_objs = _db_access.get(
+            models.TestBase,
+            first_n=2,
+            sort_result_by={"test_int": "desc", "id": "asc"}
+        )
+        self.assertEqual(retrieved_objs[0].test_int, 120)
+        self.assertEqual(retrieved_objs[0].id, 3)
+        self.assertEqual(retrieved_objs[1].test_int, 100)
+        self.assertEqual(retrieved_objs[1].id, 1)
+
+    def tearDown(self) -> None:
+        if os.path.isfile("tests/database/test_get_last_n.db"):
+            os.remove("tests/database/test_get_last_n.db")
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/tests/utils/setup_utils.py
+++ b/tests/utils/setup_utils.py
@@ -24,3 +24,4 @@ def create_route(app: _TestApp, stop_ids: tuple[int,...]) -> None:
     with app.app.test_client() as c:
         route = _models.Route(name=f"test_route_{timestamp_ms()}", stop_ids=stop_ids)
         c.post("/v2/management/route", json=route)
+


### PR DESCRIPTION
GET methods returning the Order States or Car States can now use an additional filter to return to N newest states.

This is enabled by specifying an additional lastN=<max-number-of-returned-states> query parameter. 

This filtering is done AFTER the states were filtered using the order ID (or car ID) and by their timestamp using the since parameter.

This option maximum number of returned states should be in the future added to any endpoint returning States of some entity, as is now described in /docs/development.md.

Closes BAF-821.