### PR TITLE
Order has is visible attribute

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -26,14 +26,5 @@ fleet_management_api/models/route_visualization.py
 fleet_management_api/models/stop.py
 fleet_management_api/openapi/openapi.yaml
 fleet_management_api/test/__init__.py
-fleet_management_api/test/test_api_controller.py
-fleet_management_api/test/test_car_controller.py
-fleet_management_api/test/test_car_state_controller.py
-fleet_management_api/test/test_order_controller.py
-fleet_management_api/test/test_order_state_controller.py
-fleet_management_api/test/test_platform_hw_controller.py
-fleet_management_api/test/test_route_controller.py
-fleet_management_api/test/test_security_controller.py
-fleet_management_api/test/test_stop_controller.py
 fleet_management_api/typing_utils.py
 fleet_management_api/util.py

--- a/fleet_management_api/api_impl/obj_to_db.py
+++ b/fleet_management_api/api_impl/obj_to_db.py
@@ -71,12 +71,11 @@ def order_to_db_model(order: _models.Order) -> _db_models.OrderDBModel:
         id=order.id,
         timestamp=_tstamp.timestamp_ms(),
         priority=order.priority,
-        user_id=order.user_id,
         car_id=order.car_id,
         target_stop_id=order.target_stop_id,
         stop_route_id=order.stop_route_id,
         notification_phone=notification_phone,
-        updated=True,
+        is_visible=order.is_visible
     )
 
 
@@ -89,12 +88,12 @@ def order_from_db_model(order_db_model: _db_models.OrderDBModel, last_state: _mo
         id=order_db_model.id,
         timestamp=order_db_model.timestamp,
         priority=order_db_model.priority,
-        user_id=order_db_model.user_id,
         car_id=order_db_model.car_id,
         target_stop_id=order_db_model.target_stop_id,
         stop_route_id=order_db_model.stop_route_id,
         notification_phone=notification_phone,
         last_state=last_state,
+        is_visible=order_db_model.is_visible
     )
 
 

--- a/fleet_management_api/database/db_models.py
+++ b/fleet_management_api/database/db_models.py
@@ -95,13 +95,12 @@ class OrderDBModel(Base):
     __tablename__ = "orders"
 
     priority: _Mapped[str] = _mapped_column(_sqa.String)
-    user_id: _Mapped[int] = _mapped_column(_sqa.Integer)
     timestamp: _Mapped[int] = _mapped_column(_sqa.BigInteger)
     target_stop_id: _Mapped[int] = _mapped_column(_sqa.ForeignKey("stops.id"), nullable=False)
     stop_route_id: _Mapped[int] = _mapped_column(_sqa.Integer)
     notification_phone: _Mapped[dict] = _mapped_column(_sqa.JSON)
-    updated: _Mapped[bool] = _mapped_column(_sqa.Boolean)
     car_id: _Mapped[int] = _mapped_column(_sqa.ForeignKey("cars.id"), nullable=False)
+    is_visible: _Mapped[bool] = _mapped_column(_sqa.Boolean)
 
     states: _Mapped[list["OrderStateDBModel"]] = _relationship(
         "OrderStateDBModel",
@@ -115,7 +114,7 @@ class OrderDBModel(Base):
 
     def __repr__(self) -> str:
         return (
-            f"Order(ID={self.id}, priority={self.priority}, user_ID={self.user_id}, "
+            f"Order(ID={self.id}, priority={self.priority}, is_visible={self.is_visible}, "
             f"car_ID={self.car_id}, target_stop_ID={self.target_stop_id}, "
             f"stop_route_ID={self.stop_route_id}, notification_phone={self.notification_phone})"
         )

--- a/fleet_management_api/models/order.py
+++ b/fleet_management_api/models/order.py
@@ -18,15 +18,13 @@ class Order(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, id=None, priority='normal', user_id=None, timestamp=None, car_id=None, notification=None, target_stop_id=None, stop_route_id=None, notification_phone=None, last_state=None):  # noqa: E501
+    def __init__(self, id=None, priority='normal', timestamp=None, car_id=None, notification=None, target_stop_id=None, stop_route_id=None, notification_phone=None, last_state=None, is_visible=True):  # noqa: E501
         """Order - a model defined in OpenAPI
 
         :param id: The id of this Order.  # noqa: E501
         :type id: int
         :param priority: The priority of this Order.  # noqa: E501
         :type priority: str
-        :param user_id: The user_id of this Order.  # noqa: E501
-        :type user_id: int
         :param timestamp: The timestamp of this Order.  # noqa: E501
         :type timestamp: int
         :param car_id: The car_id of this Order.  # noqa: E501
@@ -41,36 +39,37 @@ class Order(Model):
         :type notification_phone: MobilePhone
         :param last_state: The last_state of this Order.  # noqa: E501
         :type last_state: OrderState
+        :param is_visible: The is_visible of this Order.  # noqa: E501
+        :type is_visible: bool
         """
         self.openapi_types = {
             'id': int,
             'priority': str,
-            'user_id': int,
             'timestamp': int,
             'car_id': int,
             'notification': str,
             'target_stop_id': int,
             'stop_route_id': int,
             'notification_phone': MobilePhone,
-            'last_state': OrderState
+            'last_state': OrderState,
+            'is_visible': bool
         }
 
         self.attribute_map = {
             'id': 'id',
             'priority': 'priority',
-            'user_id': 'userId',
             'timestamp': 'timestamp',
             'car_id': 'carId',
             'notification': 'notification',
             'target_stop_id': 'targetStopId',
             'stop_route_id': 'stopRouteId',
             'notification_phone': 'notificationPhone',
-            'last_state': 'lastState'
+            'last_state': 'lastState',
+            'is_visible': 'isVisible'
         }
 
         self._id = id
         self._priority = priority
-        self._user_id = user_id
         self._timestamp = timestamp
         self._car_id = car_id
         self._notification = notification
@@ -78,6 +77,7 @@ class Order(Model):
         self._stop_route_id = stop_route_id
         self._notification_phone = notification_phone
         self._last_state = last_state
+        self._is_visible = is_visible
 
     @classmethod
     def from_dict(cls, dikt) -> 'Order':
@@ -135,29 +135,6 @@ class Order(Model):
             raise ValueError("Invalid value for `priority`, must be a follow pattern or equal to `/^(low|normal|high)$/`")  # noqa: E501
 
         self._priority = priority
-
-    @property
-    def user_id(self) -> int:
-        """Gets the user_id of this Order.
-
-
-        :return: The user_id of this Order.
-        :rtype: int
-        """
-        return self._user_id
-
-    @user_id.setter
-    def user_id(self, user_id: int):
-        """Sets the user_id of this Order.
-
-
-        :param user_id: The user_id of this Order.
-        :type user_id: int
-        """
-        if user_id is None:
-            raise ValueError("Invalid value for `user_id`, must not be `None`")  # noqa: E501
-
-        self._user_id = user_id
 
     @property
     def timestamp(self) -> int:
@@ -313,3 +290,24 @@ class Order(Model):
         """
 
         self._last_state = last_state
+
+    @property
+    def is_visible(self) -> bool:
+        """Gets the is_visible of this Order.
+
+
+        :return: The is_visible of this Order.
+        :rtype: bool
+        """
+        return self._is_visible
+
+    @is_visible.setter
+    def is_visible(self, is_visible: bool):
+        """Sets the is_visible of this Order.
+
+
+        :param is_visible: The is_visible of this Order.
+        :type is_visible: bool
+        """
+
+        self._is_visible = is_visible

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 3.0.1
+  version: 3.1.0
 servers:
 - url: /v2/management
 security:

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -709,7 +709,6 @@ paths:
             application/json:
               example:
               - priority: normal
-                userId: 1
                 carId: 1
                 timestamp: 1713256508978
                 targetStopId: 1
@@ -717,6 +716,7 @@ paths:
                 stopRouteId: 1
                 notificationPhone:
                   phone: "+420123456789"
+                isVisible: true
               schema:
                 items:
                   $ref: '#/components/schemas/Order'
@@ -2892,13 +2892,13 @@ components:
           phone: "+420123456789"
         targetStopId: 1
         id: 1
+        isVisible: true
         priority: normal
         lastState:
           orderId: 1
           id: 1
           status: to_accept
           timestamp: 1616425275913
-        userId: 1
         timestamp: 1616425275913
         carId: 1
       properties:
@@ -2913,11 +2913,6 @@ components:
           pattern: ^(low|normal|high)$
           title: priority
           type: string
-        userId:
-          example: 1
-          format: int32
-          title: Id
-          type: integer
         timestamp:
           description: A Unix timestamp in milliseconds. The timestamp is used to
             determine the time of creation of an object.
@@ -2948,11 +2943,14 @@ components:
           $ref: '#/components/schemas/MobilePhone'
         lastState:
           $ref: '#/components/schemas/OrderState'
+        isVisible:
+          default: true
+          title: isVisible
+          type: boolean
       required:
       - carId
       - stopRouteId
       - targetStopId
-      - userId
       title: Order
       type: object
     Priority:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 3.0.1
+  version: 3.1.0
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com

--- a/openapi/order.yaml
+++ b/openapi/order.yaml
@@ -54,13 +54,13 @@ paths:
                 [
                   {
                     "priority": "normal",
-                    "userId": 1,
                     "carId": 1,
                     "timestamp": 1713256508978,
                     "targetStopId": 1,
                     "notification": "Order notification",
                     "stopRouteId": 1,
-                    "notificationPhone": {"phone":'+420123456789'}
+                    "notificationPhone": {"phone":'+420123456789'},
+                    "isVisible": true
                   }
                 ]
         '401':
@@ -287,7 +287,6 @@ components:
       type: object
       description: Order object structure.
       required:
-        - userId
         - carId
         - targetStopId
         - stopRouteId
@@ -296,8 +295,6 @@ components:
           $ref: 'common_models.yaml#/components/schemas/Id'
         priority:
           $ref: "#/components/schemas/Priority"
-        userId:
-          $ref: 'common_models.yaml#/components/schemas/Id'
         timestamp:
           $ref: 'common_models.yaml#/components/schemas/Timestamp'
         carId:
@@ -313,6 +310,9 @@ components:
           $ref: 'common_models.yaml#/components/schemas/MobilePhone'
         lastState:
           $ref: '#/components/schemas/OrderState'
+        isVisible:
+          type: boolean
+          default: true
     OrderState:
       type: object
       description: Order state object structure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "3.0.1"
+version = "3.1.0"
 
 
 [tool.setuptools.packages.find]

--- a/tests/controllers/car/test_car_controller.py
+++ b/tests/controllers/car/test_car_controller.py
@@ -297,7 +297,7 @@ class Test_Deleting_Car(unittest.TestCase):
     def test_car_with_assigned_order_cannot_be_deleted(self):
         order = Order(
             id=1,
-            user_id=789,
+            is_visible=True,
             car_id=1,
             target_stop_id=2,
             stop_route_id=1,

--- a/tests/controllers/order/test_get_last_order_state.py
+++ b/tests/controllers/order/test_get_last_order_state.py
@@ -26,14 +26,14 @@ class Test_Order_Is_Returned_With_Its_Last_State(unittest.TestCase):
             platform_hw_id=1, name="car1", car_admin_phone=MobilePhone(phone="123456789")
         )
         self.order_1 = Order(
-            user_id=1,
+            is_visible=True,
             target_stop_id=1,
             stop_route_id=1,
             car_id=1,
             notification_phone=MobilePhone(phone="123456789"),
         )
         self.order_2 = Order(
-            user_id=1,
+            is_visible=True,
             target_stop_id=2,
             stop_route_id=1,
             car_id=1,

--- a/tests/controllers/order/test_get_order_state.py
+++ b/tests/controllers/order/test_get_order_state.py
@@ -24,7 +24,7 @@ class Test_Waiting_For_Order_States_To_Be_Sent_Do_API(unittest.TestCase):
         car = Car(name="car1", platform_hw_id=1, car_admin_phone=MobilePhone(phone="1234567890"))
         order = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -87,14 +87,14 @@ class Test_Wait_For_Order_State_For_Given_Order(unittest.TestCase):
         )
         order_1 = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
             notification_phone={},
         )
         order_2 = Order(
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -139,7 +139,7 @@ class Test_Timeouts(unittest.TestCase):
         )
         order = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -193,7 +193,7 @@ class Test_Filtering_Order_State_By_Since_Parameter(unittest.TestCase):
         car = Car(name="car1", platform_hw_id=1, car_admin_phone=MobilePhone(phone="1234567890"))
         order_1 = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -201,7 +201,7 @@ class Test_Filtering_Order_State_By_Since_Parameter(unittest.TestCase):
         )
         order_2 = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -292,7 +292,7 @@ class Test_Filtering_Order_States_By_Car_ID(unittest.TestCase):
         car_2 = Car(name="car2", platform_hw_id=2, car_admin_phone=MobilePhone(phone="1234567890"))
         order_1 = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -300,7 +300,7 @@ class Test_Filtering_Order_States_By_Car_ID(unittest.TestCase):
         )
         order_2 = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=2,
             target_stop_id=1,
             stop_route_id=1,
@@ -361,7 +361,7 @@ class Test_Filtering_Order_States_By_Car_ID(unittest.TestCase):
                 )
                 order = Order(
                     priority="high",
-                    user_id=1,
+                    is_visible=True,
                     car_id=3,
                     target_stop_id=1,
                     stop_route_id=1,

--- a/tests/controllers/order/test_max_number_of_orders.py
+++ b/tests/controllers/order/test_max_number_of_orders.py
@@ -36,7 +36,7 @@ class Test_Number_Of_Active_Orders(unittest.TestCase):
 
     def test_is_increased_whenever_new_order_is_sucessfully_posted(self):
         self.assertEqual(n_of_active_orders(1), 0)
-        order = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order])
             self.assertEqual(n_of_active_orders(1), 1)
@@ -44,7 +44,7 @@ class Test_Number_Of_Active_Orders(unittest.TestCase):
             self.assertEqual(n_of_active_orders(1), 2)
 
     def test_is_decreased_when_order_is_done(self):
-        order = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         with self.app.app.test_client() as c:
             order_id = c.post("/v2/management/order", json=[order]).json[0]["id"]
             self.assertEqual(n_of_active_orders(1), 1)
@@ -56,7 +56,7 @@ class Test_Number_Of_Active_Orders(unittest.TestCase):
             self.assertEqual(n_of_active_orders(1), 0)
 
     def test_is_decreased_whenever_order_is_canceled(self):
-        order = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         with self.app.app.test_client() as c:
             order_id = c.post("/v2/management/order", json=[order]).json[0]["id"]
             self.assertEqual(n_of_active_orders(1), 1)
@@ -68,7 +68,7 @@ class Test_Number_Of_Active_Orders(unittest.TestCase):
             self.assertEqual(n_of_active_orders(1), 0)
 
     def test_is_decreased_when_order_is_deleted(self):
-        order = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order])
             self.assertEqual(n_of_active_orders(1), 1)
@@ -76,7 +76,7 @@ class Test_Number_Of_Active_Orders(unittest.TestCase):
             self.assertEqual(n_of_active_orders(1), 0)
 
     def test_the_number_is_unchanged_when_restarting_the_application(self):
-        order = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order, order])
             self.assertEqual(n_of_active_orders(car_id=1), 2)
@@ -105,9 +105,9 @@ class Test_Maximum_Number_Of_Active_Orders(unittest.TestCase):
 
     def test_max_number_of_orders(self):
         set_max_n_of_active_orders(3)
-        order_1 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
-        order_2 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
-        order_3 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_1 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_2 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_3 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order_1])
             c.post("/v2/management/order", json=[order_2])
@@ -115,17 +115,17 @@ class Test_Maximum_Number_Of_Active_Orders(unittest.TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(n_of_active_orders(1), 3)
 
-        order_4 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_4 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         with self.app.app.test_client() as c:
             response = c.post("/v2/management/order", json=[order_4])
             self.assertEqual(response.status_code, 403)
 
     def test_max_number_of_orders_is_checked_separately_for_each_car(self):
         set_max_n_of_active_orders(2)
-        order_1 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
-        order_2 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
-        order_3 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
-        order_4 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=2)
+        order_1 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_2 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_3 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_4 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=2)
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order_1, order_2])
             response = c.post("/v2/management/order", json=[order_3])
@@ -154,7 +154,7 @@ class Test_Number_Of_Inactive_Orders_Lower_Than_Maximum(unittest.TestCase):
 
     def test_is_increased_or_when_order_receives_done_status(self):
         self.assertEqual(n_of_active_orders(1), 0)
-        order = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         done_state = OrderState(status=OrderStatus.DONE, order_id=1)
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order])
@@ -165,7 +165,7 @@ class Test_Number_Of_Inactive_Orders_Lower_Than_Maximum(unittest.TestCase):
 
     def test_is_decreased_when_done_order_is_deleted(self):
         self.assertEqual(n_of_active_orders(1), 0)
-        order = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         done_state = OrderState(status=OrderStatus.DONE, order_id=1)
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order])
@@ -176,7 +176,7 @@ class Test_Number_Of_Inactive_Orders_Lower_Than_Maximum(unittest.TestCase):
 
     def test_is_increased_or_when_order_receives_canceled_status(self):
         self.assertEqual(n_of_active_orders(1), 0)
-        order = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         canceled_state = OrderState(status=OrderStatus.CANCELED, order_id=1)
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order])
@@ -186,7 +186,7 @@ class Test_Number_Of_Inactive_Orders_Lower_Than_Maximum(unittest.TestCase):
 
     def test_is_decreased_when_canceled_order_is_deleted(self):
         self.assertEqual(n_of_active_orders(1), 0)
-        order = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         canceled_state = OrderState(status=OrderStatus.CANCELED, order_id=1)
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order])
@@ -196,7 +196,7 @@ class Test_Number_Of_Inactive_Orders_Lower_Than_Maximum(unittest.TestCase):
             self.assertEqual(n_of_inactive_orders(1), 0)
 
     def test_the_number_is_unchanged_when_restarting_the_application(self):
-        order = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order, order])
             c.post(
@@ -235,9 +235,9 @@ class Test_Automatic_Removal_Of_Inactive_Orders(unittest.TestCase):
     ):
         set_max_n_of_active_orders(None)
         set_max_n_of_inactive_orders(2)
-        order_1 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
-        order_2 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
-        order_3 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_1 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_2 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_3 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order_1, order_2])
             c.post(
@@ -258,9 +258,9 @@ class Test_Automatic_Removal_Of_Inactive_Orders(unittest.TestCase):
     def test_starts_from_order_that_was_completed_first(self):
         set_max_n_of_active_orders(None)
         set_max_n_of_inactive_orders(2)
-        order_1 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
-        order_2 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
-        order_3 = Order(user_id=1, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_1 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_2 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_3 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         car_id = 1
         with self.app.app.test_client() as c:
             c.post("/v2/management/order", json=[order_1, order_2])

--- a/tests/controllers/order/test_order_controller.py
+++ b/tests/controllers/order/test_order_controller.py
@@ -35,7 +35,7 @@ class Test_Sending_Order(unittest.TestCase):
     def test_sending_order_to_exising_car(self, mock_timestamp: Mock):
         mock_timestamp.return_value = 1000
         order = Order(
-            user_id=789,
+            is_visible=True,
             timestamp=1000,
             car_id=1,
             target_stop_id=2,
@@ -60,7 +60,7 @@ class Test_Sending_Order(unittest.TestCase):
     def test_sending_order_to_non_exising_car_yields_code_404(self):
         nonexistent_car_id = 6546515
         order = Order(
-            user_id=789,
+            is_visible=True,
             car_id=nonexistent_car_id,
             target_stop_id=2,
             stop_route_id=1,
@@ -72,7 +72,7 @@ class Test_Sending_Order(unittest.TestCase):
 
     def test_sending_order_referencing_nonexistent_stop_yields_code_404(self):
         order = Order(
-            user_id=789,
+            is_visible=True,
             car_id=1,
             target_stop_id=16316516,
             stop_route_id=1,
@@ -84,7 +84,7 @@ class Test_Sending_Order(unittest.TestCase):
 
     def test_specifying_route_not_containing_the_target_stop_yields_code_400(self):
         order = Order(
-            user_id=789,
+            is_visible=True,
             car_id=1,
             target_stop_id=3,
             stop_route_id=1,
@@ -174,14 +174,14 @@ class Test_All_Retrieving_Orders(unittest.TestCase):
             self.car_2.id = response.json[0]["id"]
 
         self.order_1 = Order(
-            user_id=789,
+            is_visible=True,
             car_id=1,
             target_stop_id=2,
             stop_route_id=1,
             notification_phone=MobilePhone(phone="1234567890"),
         )
         self.order_2 = Order(
-            user_id=789,
+            is_visible=True,
             car_id=2,
             target_stop_id=2,
             stop_route_id=1,
@@ -224,7 +224,7 @@ class Test_All_Retrieving_Orders(unittest.TestCase):
 
     def test_retrieving_all_orders_when_some_orders_exist_yields_code_200(self):
         order = Order(
-            user_id=789,
+            is_visible=True,
             car_id=1,
             target_stop_id=2,
             stop_route_id=1,
@@ -259,7 +259,7 @@ class Test_Retrieving_Single_Order_From_The_Database(unittest.TestCase):
     def test_retrieving_existing_order(self, mock_timestamp: Mock):
         mock_timestamp.return_value = 1000
         order = Order(
-            user_id=789,
+            is_visible=True,
             timestamp=1000,
             car_id=1,
             target_stop_id=4,
@@ -303,7 +303,7 @@ class Test_Deleting_Order(unittest.TestCase):
         with self.app.app.test_client() as c:
             c.post("/v2/management/car", json=[self.car])
             self.order = Order(
-                user_id=789,
+                is_visible=True,
                 car_id=1,
                 target_stop_id=6,
                 stop_route_id=1,
@@ -346,14 +346,14 @@ class Test_Retrieving_Orders_By_Creation_Timestamp(unittest.TestCase):
             c.post("/v2/management/car", json=[self.car])
 
         self.order_1 = Order(
-            user_id=789,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
             notification_phone=MobilePhone(phone="1234567890"),
         )
         self.order_2 = Order(
-            user_id=789,
+            is_visible=True,
             car_id=1,
             target_stop_id=2,
             stop_route_id=1,

--- a/tests/controllers/order/test_order_state_controller.py
+++ b/tests/controllers/order/test_order_state_controller.py
@@ -30,7 +30,7 @@ class Test_Adding_State_Of_Existing_Order(unittest.TestCase):
         order = Order(
             id=12,
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -75,7 +75,7 @@ class Test_Adding_State_Using_Example_From_Spec(unittest.TestCase):
             example = spec["components"]["schemas"]["OrderState"]["example"]
             order = Order(
                 priority="high",
-                user_id=1,
+                is_visible=True,
                 car_id=1,
                 target_stop_id=1,
                 stop_route_id=1,
@@ -102,7 +102,7 @@ class Test_Getting_All_Order_States_For_Given_Order(unittest.TestCase):
         car = Car(id=1, name="car1", platform_hw_id=1, car_admin_phone={})
         order = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -155,7 +155,7 @@ class Test_Getting_Order_State_For_Given_Order(unittest.TestCase):
         car = Car(name="car1", platform_hw_id=1, car_admin_phone={})
         order_1 = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -163,7 +163,7 @@ class Test_Getting_Order_State_For_Given_Order(unittest.TestCase):
         )
         order_2 = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -207,7 +207,7 @@ class Test_Maximum_Number_Of_States_Stored(unittest.TestCase):
         car = Car(name="car1", platform_hw_id=1, car_admin_phone={})
         order_1 = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -215,7 +215,7 @@ class Test_Maximum_Number_Of_States_Stored(unittest.TestCase):
         )
         order_2 = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -296,7 +296,7 @@ class Test_Deleting_Order_States_When_Deleting_Order(unittest.TestCase):
         car = Car(name="car1", platform_hw_id=1, car_admin_phone={})
         order = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -304,7 +304,7 @@ class Test_Deleting_Order_States_When_Deleting_Order(unittest.TestCase):
         )
         other_order = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -350,7 +350,7 @@ class Test_Accepting_Order_States_After_Receiving_State_With_Final_Status(unitte
         car = Car(name="car1", platform_hw_id=1, car_admin_phone={})
         order = Order(
             priority="high",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,
@@ -441,7 +441,7 @@ class Test_Recongnizing_Done_And_Canceled_Orders_After_Restarting_Application(un
         create_stops(self.app, 1)
         create_route(self.app, stop_ids=(1,))
         car = Car(name="car1", platform_hw_id=1, car_admin_phone={})
-        order = Order(user_id=1, car_id=1, target_stop_id=1, stop_route_id=1, notification_phone={})
+        order = Order(is_visible=True, car_id=1, target_stop_id=1, stop_route_id=1, notification_phone={})
         done_state = OrderState(status=OrderStatus.DONE, order_id=1)
         next_state = OrderState(status=OrderStatus.IN_PROGRESS, order_id=1)
         with self.app.app.test_client() as c:
@@ -465,7 +465,7 @@ class Test_Recongnizing_Done_And_Canceled_Orders_After_Restarting_Application(un
         create_stops(self.app, 1)
         create_route(self.app, stop_ids=(1,))
         car = Car(name="car1", platform_hw_id=1, car_admin_phone={})
-        order = Order(user_id=1, car_id=1, target_stop_id=1, stop_route_id=1, notification_phone={})
+        order = Order(is_visible=True, car_id=1, target_stop_id=1, stop_route_id=1, notification_phone={})
         canceled_state = OrderState(status=OrderStatus.CANCELED, order_id=1)
         next_state = OrderState(status=OrderStatus.IN_PROGRESS, order_id=1)
         with self.app.app.test_client() as c:
@@ -502,7 +502,7 @@ class Test_Returning_Last_N_Order_States(unittest.TestCase):
         create_route(self.app, stop_ids=(1,))
         car = Car(platform_hw_id=1, name="car1", car_admin_phone=PHONE)
         order = Order(
-            user_id=1, car_id=1, target_stop_id=1, stop_route_id=1, notification_phone=PHONE
+            is_visible=True, car_id=1, target_stop_id=1, stop_route_id=1, notification_phone=PHONE
         )
         with self.app.app.test_client() as c:
             mocked_timestamp.return_value = 0
@@ -584,10 +584,10 @@ class Test_Returning_Last_N_Car_States_For_Given_Car(unittest.TestCase):
         create_route(self.app, stop_ids=(1, 2))
         car_1 = Car(platform_hw_id=1, name="car1", car_admin_phone=PHONE)
         self.order_1 = Order(
-            user_id=1, car_id=1, target_stop_id=1, stop_route_id=1, notification_phone=PHONE
+            is_visible=True, car_id=1, target_stop_id=1, stop_route_id=1, notification_phone=PHONE
         )
         self.order_2 = Order(
-            user_id=1, car_id=1, target_stop_id=2, stop_route_id=1, notification_phone=PHONE
+            is_visible=True, car_id=1, target_stop_id=2, stop_route_id=1, notification_phone=PHONE
         )
 
         with self.app.app.test_client() as c:

--- a/tests/controllers/route/test_route_controller.py
+++ b/tests/controllers/route/test_route_controller.py
@@ -151,7 +151,7 @@ class Test_Deleting_Route(unittest.TestCase):
             platform_hw_id=1,
             car_admin_phone=MobilePhone(phone="123456789"),
         )
-        order = Order(id=1, stop_route_id=1, target_stop_id=1, user_id=1, car_id=1)
+        order = Order(id=1, stop_route_id=1, target_stop_id=1, is_visible=True, car_id=1)
         with self.app.app.test_client() as c:
             response = c.post("/v2/management/platformhw", json=[platform_hw])
             c.post("/v2/management/car", json=[car])

--- a/tests/controllers/route/test_stop_controller.py
+++ b/tests/controllers/route/test_stop_controller.py
@@ -244,7 +244,7 @@ class Test_Stop_Cannot_Be_Deleted_If_Assigned_To_Order(unittest.TestCase):
         self.order = _models.Order(
             id=1,
             priority="normal",
-            user_id=1,
+            is_visible=True,
             car_id=1,
             target_stop_id=1,
             stop_route_id=1,

--- a/tests/controllers/test_db_models.py
+++ b/tests/controllers/test_db_models.py
@@ -159,21 +159,22 @@ class Test_Creating_Car_State_DB_Model(unittest.TestCase):
 
 class Test_Creating_Order_DB_Model(unittest.TestCase):
     def test_creating_db_model_from_order_preserves_attribute_values(self):
-        order = Order(user_id=789, car_id=12, target_stop_id=7, stop_route_id=8)
+        order = Order(car_id=12, target_stop_id=7, stop_route_id=8, is_visible=False)
         order_db_model = _obj_to_db.order_to_db_model(order)
         self.assertEqual(order_db_model.priority, order.priority)
-        self.assertEqual(order_db_model.user_id, order.user_id)
+        self.assertEqual(order_db_model.is_visible, order.is_visible)
         self.assertEqual(order_db_model.car_id, order.car_id)
         self.assertEqual(order_db_model.target_stop_id, order.target_stop_id)
         self.assertEqual(order_db_model.stop_route_id, order.stop_route_id)
         self.assertEqual(order_db_model.notification_phone, order.notification_phone)
+        self.assertEqual(order_db_model.is_visible, order.is_visible)
 
     def test_creating_db_model_from_order_with_only_required_attributes_specified_preserves_attribute_values(
         self,
     ):
         order = Order(
             priority="normal",
-            user_id=789,
+            is_visible=False,
             car_id=12,
             target_stop_id=7,
             stop_route_id=8,
@@ -181,14 +182,15 @@ class Test_Creating_Order_DB_Model(unittest.TestCase):
         )
         order_db_model = _obj_to_db.order_to_db_model(order)
         self.assertEqual(order_db_model.priority, order.priority)
-        self.assertEqual(order_db_model.user_id, order.user_id)
+        self.assertEqual(order_db_model.is_visible, order.is_visible)
         self.assertEqual(order_db_model.car_id, order.car_id)
         self.assertEqual(order_db_model.target_stop_id, order.target_stop_id)
         self.assertEqual(order_db_model.stop_route_id, order.stop_route_id)
         self.assertEqual(order_db_model.notification_phone, order.notification_phone.to_dict())
+        self.assertEqual(order_db_model.is_visible, order.is_visible)
 
     def test_order_converted_to_db_model_and_back_is_unchanged(self):
-        order_in = Order(id=1, user_id=789, car_id=12, target_stop_id=7, stop_route_id=8)
+        order_in = Order(id=1, is_visible=False, car_id=12, target_stop_id=7, stop_route_id=8)
         order_out = _obj_to_db.order_from_db_model(
             _obj_to_db.order_to_db_model(order_in), last_state=LAST_ORDER_STATE
         )
@@ -202,7 +204,7 @@ class Test_Creating_Order_DB_Model(unittest.TestCase):
     ):
         order_in = Order(
             priority="high",
-            user_id=789,
+            is_visible=True,
             car_id=12,
             target_stop_id=7,
             stop_route_id=8,

--- a/tests/script_args/test_config.json
+++ b/tests/script_args/test_config.json
@@ -8,8 +8,7 @@
         "client_id": "",
         "client_secret_key": "",
         "scope": "",
-        "realm": "",
-        "keycloak_public_key_file": "config/keycloak.pem"
+        "realm": ""
     },
     "database": {
         "connection": {

--- a/tests/script_args/test_config.py
+++ b/tests/script_args/test_config.py
@@ -99,10 +99,6 @@ class Test_Security_Config(unittest.TestCase):
         self.assertEqual(config_obj.client_secret_key, self.config_dict["client_secret_key"])
         self.assertEqual(config_obj.scope, self.config_dict["scope"])
         self.assertEqual(config_obj.realm, self.config_dict["realm"])
-        self.assertEqual(
-            str(config_obj.keycloak_public_key_file),
-            self.config_dict["keycloak_public_key_file"],
-        )
 
     def test_raise_error_when_data_is_missing(self):
         for key in self.config_dict.keys():
@@ -111,16 +107,6 @@ class Test_Security_Config(unittest.TestCase):
                 invalid_config_dict.pop(key)
                 with self.assertRaises(pydantic.ValidationError):
                     _configs.Security(**invalid_config_dict)
-
-    def test_nonempty_invalid_file_path_of_keycloak_public_key_file_raises_error(self):
-        self.config_dict["keycloak_public_key_file"] = "invalid_file_path"
-        with self.assertRaises(pydantic.ValidationError):
-            _configs.Security(**self.config_dict)
-
-    def test_empty_keycloak_public_key_file_path_is_allowed(self):
-        self.config_dict["keycloak_public_key_file"] = ""
-        config_obj = _configs.Security(**self.config_dict)
-        self.assertEqual(str(config_obj.keycloak_public_key_file), "")
 
 
 class Test_API_Config(unittest.TestCase):


### PR DESCRIPTION
- 'userId' is removed from the Order model (it is not used and will not be used).
- 'updated' attribute is removed from OrderDBModel (originally added to denote orders with new order states, that were not accessed by GET method on /orderstate endpoint). This was never actually used.
-  isVisible attribute was added to the Order model, allowing to hide/show Orders in apps controlling the Fleet Management (e.g., the Fleet Management GUI).

- 'keycloack_public_key_file' was removed from the test_config for security unit tests and also from these tests. The file is not a part of SecurityConfig since API version 3.0.1 and checking for its presence make these tests to break (randomly).

Closes [BAIP-248](https://youtrack.bringauto.com/issue/BAIP-248/Remove-UserId-from-Order-model)