### PR TITLE
Fix checking max n of active orders

### DIFF
--- a/fleet_management_api/controllers/order_state_controller.py
+++ b/fleet_management_api/controllers/order_state_controller.py
@@ -16,7 +16,7 @@ def create_order_states(order_state):  # noqa: E501
     :param order_state: A list of Order State models in JSON format.
     :type order_state: list | bytes
 
-    :rtype: Union[OrderState, Tuple[OrderState, int], Tuple[OrderState, int, Dict[str, str]]
+    :rtype: Union[List[OrderState], Tuple[List[OrderState], int], Tuple[List[OrderState], int, Dict[str, str]]
     """
     if connexion.request.is_json:
         order_state = [OrderState.from_dict(d) for d in connexion.request.get_json()]  # noqa: E501

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 3.1.0
+  version: 3.1.1
 servers:
 - url: /v2/management
 security:

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -1207,7 +1207,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderState'
+                items:
+                  $ref: '#/components/schemas/OrderState'
+                type: array
           description: The new Order States have been successfully posted.
         "400":
           content:

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 3.1.1
+  version: 3.1.2
 servers:
 - url: /v2/management
 security:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 3.1.0
+  version: 3.1.1
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 3.1.1
+  version: 3.1.2
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com

--- a/openapi/order.yaml
+++ b/openapi/order.yaml
@@ -198,7 +198,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderState'
+                type: array
+                items:
+                  $ref: '#/components/schemas/OrderState'
         '400':
           $ref: 'errors.yaml#/components/responses/BadRequest'
         '401':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "3.1.0"
+version = "3.1.1"
 
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "3.1.1"
+version = "3.1.2"
 
 
 [tool.setuptools.packages.find]

--- a/tests/controllers/order/test_max_number_of_orders.py
+++ b/tests/controllers/order/test_max_number_of_orders.py
@@ -109,9 +109,7 @@ class Test_Maximum_Number_Of_Active_Orders(unittest.TestCase):
         order_2 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         order_3 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         with self.app.app.test_client() as c:
-            c.post("/v2/management/order", json=[order_1])
-            c.post("/v2/management/order", json=[order_2])
-            response = c.post("/v2/management/order", json=[order_3])
+            response = c.post("/v2/management/order", json=[order_1, order_2, order_3])
             self.assertEqual(response.status_code, 200)
             self.assertEqual(n_of_active_orders(1), 3)
 
@@ -119,6 +117,16 @@ class Test_Maximum_Number_Of_Active_Orders(unittest.TestCase):
         with self.app.app.test_client() as c:
             response = c.post("/v2/management/order", json=[order_4])
             self.assertEqual(response.status_code, 403)
+
+    def test_exceeding_max_number_of_orders_in_a_single_request_does_not_add_any_order(self):
+        set_max_n_of_active_orders(2)
+        order_1 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_2 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_3 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        with self.app.app.test_client() as c:
+            response = c.post("/v2/management/order", json=[order_1, order_2, order_3])
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(n_of_active_orders(1), 0)
 
     def test_max_number_of_orders_is_checked_separately_for_each_car(self):
         set_max_n_of_active_orders(2)
@@ -132,6 +140,20 @@ class Test_Maximum_Number_Of_Active_Orders(unittest.TestCase):
             self.assertEqual(response.status_code, 403)
             response = c.post("/v2/management/order", json=[order_4])
             self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(c.get("/v2/management/order/1").json), 2)
+            self.assertEqual(len(c.get("/v2/management/order/2").json), 1)
+
+
+    def test_sending_orders_in_single_request_when_exceeding_max_number_for_at_least_one_car_does_not_create_any_order(self):
+        set_max_n_of_active_orders(2)
+        order_1 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_2 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_3 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
+        order_4 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=2)
+        with self.app.app.test_client() as c:
+            response = c.post("/v2/management/order", json=[order_1, order_2, order_3, order_4])
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(c.get("/v2/management/order").json, [])
 
     def tearDown(self) -> None:  # pragma: no cover
         if os.path.isfile("test_db.db"):

--- a/tests/controllers/order/test_max_number_of_orders.py
+++ b/tests/controllers/order/test_max_number_of_orders.py
@@ -111,12 +111,19 @@ class Test_Maximum_Number_Of_Active_Orders(unittest.TestCase):
         with self.app.app.test_client() as c:
             response = c.post("/v2/management/order", json=[order_1, order_2, order_3])
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(n_of_active_orders(1), 3)
+            self.assertEqual(n_of_active_orders(car_id=1), 3)
 
         order_4 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
         with self.app.app.test_client() as c:
             response = c.post("/v2/management/order", json=[order_4])
             self.assertEqual(response.status_code, 403)
+            self.assertEqual(n_of_active_orders(car_id=1), 3)
+
+        order_5 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=2)
+        with self.app.app.test_client() as c:
+            response = c.post("/v2/management/order", json=[order_5])
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(n_of_active_orders(car_id=2), 1)
 
     def test_exceeding_max_number_of_orders_in_a_single_request_does_not_add_any_order(self):
         set_max_n_of_active_orders(2)
@@ -142,7 +149,6 @@ class Test_Maximum_Number_Of_Active_Orders(unittest.TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(len(c.get("/v2/management/order/1").json), 2)
 
-
     def test_sending_orders_in_single_request_when_exceeding_max_number_for_at_least_one_car_does_not_create_any_order(self):
         set_max_n_of_active_orders(2)
         order_1 = Order(is_visible=True, target_stop_id=1, stop_route_id=1, car_id=1)
@@ -153,6 +159,7 @@ class Test_Maximum_Number_Of_Active_Orders(unittest.TestCase):
             response = c.post("/v2/management/order", json=[order_1, order_2, order_3, order_4])
             self.assertEqual(response.status_code, 403)
             self.assertEqual(c.get("/v2/management/order").json, [])
+
 
     def tearDown(self) -> None:  # pragma: no cover
         if os.path.isfile("test_db.db"):

--- a/tests/controllers/order/test_max_number_of_orders.py
+++ b/tests/controllers/order/test_max_number_of_orders.py
@@ -141,7 +141,6 @@ class Test_Maximum_Number_Of_Active_Orders(unittest.TestCase):
             response = c.post("/v2/management/order", json=[order_4])
             self.assertEqual(response.status_code, 200)
             self.assertEqual(len(c.get("/v2/management/order/1").json), 2)
-            self.assertEqual(len(c.get("/v2/management/order/2").json), 1)
 
 
     def test_sending_orders_in_single_request_when_exceeding_max_number_for_at_least_one_car_does_not_create_any_order(self):


### PR DESCRIPTION
Server must ensure maximum number of active orders (TO_ACCEPT, ACCEPTED, IN_PROGRESS) stored in database is less or equal to a maximum value specified in the server config file. This number is checked per car, i.e., for N cars in the database, the total number of stored orders can be up to N*maximum number.

Since Fleet Management API v3, multiple orders can be sent in a single request. However, when the server checked the number of active orders will not be exceeded, it assumed only a SINGLE order is added per request. 

This is fixed. Now, if 'M' orders for a given car are sent in a request and the server can accept only 'm' (m<M), then none of the  orders is accepted.

