### PR TITLE
Create default order states for all orders at once

### DIFF
--- a/fleet_management_api/api_impl/controllers/order.py
+++ b/fleet_management_api/api_impl/controllers/order.py
@@ -179,7 +179,7 @@ def create_orders() -> _Response:
                 )
 
     for order in orders:
-        order.last_state = None
+        order.last_state = None  # type: ignore
         car_id = order.car_id
         if not _car_exist(car_id):
             return _log_error_and_respond(
@@ -202,19 +202,28 @@ def create_orders() -> _Response:
             ]
         )
         order_db_models.append(_obj_to_db.order_to_db_model(order))
+
     response = _db_access.add(*order_db_models, checked=checked)
 
     if response.status_code == 200:
+        # orders are created in the database, now log them
         posted_db_models: list[_db_models.OrderDBModel] = response.body
         posted_orders: list[_models.Order] = []
+        ids: list[int] = []
         for model in posted_db_models:
             assert model.id is not None
-            db_state = _post_default_order_state(model.id).body[0]
-            state = _obj_to_db.order_state_from_db_model(db_state)
+            ids.append(model.id)
+            _log_info(f"Order (ID={model.id}) has been created.")
+
+        db_states = _post_default_order_states(ids).body
+        states = [_obj_to_db.order_state_from_db_model(db_state) for db_state in db_states]
+
+        for model, state in zip(posted_db_models, states):
             posted_order = _obj_to_db.order_from_db_model(model, state)
             _log_info(f"Order (ID={posted_order.id}) has been created.")
             _add_active_order(order.car_id, posted_order.id)
             posted_orders.append(posted_order)
+
         return _json_response(posted_orders)
     else:
         return _log_error_and_respond(
@@ -317,9 +326,9 @@ def _group_new_orders_by_car(orders: list[_models.Order]) -> dict[CarId, list[_m
     return orders_by_car
 
 
-def _post_default_order_state(order_id: int) -> _Response:
-    order_state = _models.OrderState(order_id=order_id, status=DEFAULT_STATUS)
-    response = _order_state.create_order_states_from_argument_and_post([order_state])
+def _post_default_order_states(order_ids: list[int]) -> _Response:
+    order_states = [_models.OrderState(order_id=id_, status=DEFAULT_STATUS) for id_ in order_ids]
+    response = _order_state.create_order_states_from_argument_and_post(order_states)
     return response
 
 

--- a/fleet_management_api/api_impl/controllers/order.py
+++ b/fleet_management_api/api_impl/controllers/order.py
@@ -208,7 +208,6 @@ def create_orders() -> _Response:
     if response.status_code == 200:
         # orders are created in the database, now log them
         posted_db_models: list[_db_models.OrderDBModel] = response.body
-        posted_orders: list[_models.Order] = []
         ids: list[int] = []
         for model in posted_db_models:
             assert model.id is not None
@@ -218,9 +217,9 @@ def create_orders() -> _Response:
         db_states = _post_default_order_states(ids).body
         states = [_obj_to_db.order_state_from_db_model(db_state) for db_state in db_states]
 
+        posted_orders: list[_models.Order] = []
         for model, state in zip(posted_db_models, states):
             posted_order = _obj_to_db.order_from_db_model(model, state)
-            _log_info(f"Order (ID={posted_order.id}) has been created.")
             _add_active_order(order.car_id, posted_order.id)
             posted_orders.append(posted_order)
 

--- a/tests/controllers/car/test_car_controller.py
+++ b/tests/controllers/car/test_car_controller.py
@@ -207,7 +207,7 @@ class Test_Logging_Car_Creation(unittest.TestCase):
             with app.app.test_client() as c:
                 c.post("/v2/management/car", json=[car], content_type="application/json")
                 self.assertEqual(len(logs.output), 2)
-                self.assertIn(str(car.name), logs.output[-1])
+                self.assertIn(str(car.name), logs.output[0])
 
     def test_unsuccesfull_creation_of_a_car_already_present_in_database_is_logged_as_error(
         self,


### PR DESCRIPTION
If multiple orders or cars are sent in a single request to the server, their default states are inserted into the database in a single query. 

This also means that all clients waiting for new states to be posted to the HTTP server receive all the newly inserted states. 

Before the fix, it was possible that the API might have returned only the first few of the inserted states.

This change decreases the number of requests the client needs to make to obtain all new car/order states, respectively. 

Also, all the default states of all the cars or orders added at once now have identical timestamps. Before the fix, these differed slightly.
