### PR TITLE
Baf 872/wait mechanism holds db connections

### DIFF
--- a/fleet_management_api/database/db_access.py
+++ b/fleet_management_api/database/db_access.py
@@ -252,6 +252,7 @@ def get(
         sort_result_by = {}
     table = base.__table__
     source = _get_current_connection_source(connection_source)
+    result = []
     with _Session(source) as session, session.begin():
         clauses = [
             criteria[attr_label](getattr(table.columns, attr_label))
@@ -271,13 +272,14 @@ def get(
             for item in omitted_relationships:
                 stmt = stmt.options(_noload(item))
         result = [item.copy() for item in session.scalars(stmt).all()]
-        if not result and wait:
-            result = _wait_mg.wait_for_content(
-                base.__tablename__,
-                timeout_ms,
-                validation=_functools.partial(_is_awaited_result_valid, criteria),
-            )
-        return result
+
+    if not result and wait:
+        result = _wait_mg.wait_for_content(
+            base.__tablename__,
+            timeout_ms,
+            validation=_functools.partial(_is_awaited_result_valid, criteria),
+        )
+    return result
 
 
 def get_children(

--- a/fleet_management_api/database/db_access.py
+++ b/fleet_management_api/database/db_access.py
@@ -194,16 +194,15 @@ def delete_n(
         return _text_response(f"{n_of_deleted_items} objects deleted from the database.")
 
 
-def get_by_id(
-    base: type[_Base], *ids: int, conn_source: Optional[_sqa.Engine] = None
+def get_by_id(base: type[_Base], *ids: int, engine: Optional[_sqa.Engine] = None
 ) -> list[_Base]:
     """Returns instances of the `base` with IDs from the `IDs` tuple.
 
     An optional `connection_source` may be specified to replace the otherwise used global connection
     source (an sqlalchemy Engine object).
     """
-    source = _get_current_connection_source(conn_source)
-    with _Session(source) as session, session.begin():
+    engine = _get_current_connection_source(engine)
+    with _Session(engine) as session, session.begin():
         try:
             results = []
             for id_value in ids:
@@ -288,10 +287,6 @@ def get_children(
     children_col_name: str,
     connection_source: Optional[_sqa.Engine] = None,
     criteria: Optional[dict[str, Callable[[Any], bool]]] = None,
-    wait: bool = False,
-    timeout_ms: int = 1000,
-    sort_result_by: Optional[dict[str, Order]] = None,
-    first_n: int = 0
 ) -> list[_Base]:
     """Get children of an instance of an ORM mapped class `parent_base` with `parent_id` from its `children_col_name`.
 
@@ -303,18 +298,10 @@ def get_children(
     source = _get_current_connection_source(connection_source)
     if criteria is None:
         criteria = {}
-    child_base = getattr(parent_base, children_col_name).property.mapper.class_
     with _Session(source) as session:
         try:
             raw_chilren = getattr(session.get_one(parent_base, parent_id), children_col_name)
             children = [child for child in raw_chilren if all(crit(getattr(child, attr)) for attr,crit in criteria.items())]
-            if not children and wait:
-                updated_criteria = {**criteria, parent_base.__tablename__: lambda x: x == parent_id}
-                children = _return_awaited_result(
-                    child_base,
-                    timeout_ms=timeout_ms,
-                    criteria=updated_criteria
-                )
             return children
         except _NoResultFound as e:
             raise ParentNotFound(
@@ -322,19 +309,6 @@ def get_children(
             )
         except Exception as e:
             raise e
-
-
-def _return_awaited_result(
-    base: type[_Base],
-    timeout_ms: int,
-    criteria: Optional[dict[str, Callable[[Any], bool]]] = None
-) -> list[Any]:
-
-    return _wait_mg.wait_for_content(
-        base.__tablename__,
-        timeout_ms,
-        validation=_functools.partial(_is_awaited_result_valid, criteria),
-    )
 
 
 def update(*updated: _Base) -> _Response:

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 3.1.3
+  version: 3.1.4
 servers:
 - url: /v2/management
 security:

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 3.1.2
+  version: 3.1.3
 servers:
 - url: /v2/management
 security:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 3.1.3
+  version: 3.1.4
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 3.1.2
+  version: 3.1.3
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "3.1.3"
+version = "3.1.4"
 
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "3.1.2"
+version = "3.1.3"
 
 
 [tool.setuptools.packages.find]

--- a/tests/database/test_wait_for_content.py
+++ b/tests/database/test_wait_for_content.py
@@ -6,6 +6,9 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 import time
 
+import sqlalchemy as sqa
+from sqlalchemy.pool.impl import QueuePool
+
 import fleet_management_api.database.connection as _connection
 import fleet_management_api.database.db_access as _db_access
 import tests.database.models as models
@@ -157,5 +160,41 @@ class Test_Waiting_For_New_Content_To_Be_Sent(unittest.TestCase):
             os.remove(_TEST_DB_FILE_PATH)
 
 
+class Test_Waiting_Mechanism_Releases_Connection_To_Pool(unittest.TestCase):
+    """There is a maximum number of active connections that can be opened at the same time.
+
+    To reduce the number of connections, the waiting mechanism should release the connection
+    if there are no data available. This test checks if the connection is released back to the
+    connection pool.
+
+    This releasing of a connection is possible, because the waiting request on the HTTP server
+    waits for data coming from other request to the server and does not read them from the database.
+    """
+
+    def setUp(self) -> None:
+        _connection.set_connection_source_test(_TEST_DB_FILE_PATH)
+        models.initialize_test_tables(_connection.current_connection_source())
+
+    def test_single_connection_is_reused_by_every_request_and_then_checked_in_into_pool(self):
+        test_obj = models.TestBase(test_str="test", test_int=123)
+        src = _connection.current_connection_source()
+        assert isinstance(src.pool, QueuePool)
+        def get_and_count_connections():
+            _db_access.get(models.TestBase, wait=True)
+
+        with ThreadPoolExecutor() as executor:
+            executor.submit(get_and_count_connections)
+            time.sleep(0.01)
+            executor.submit(get_and_count_connections)
+            time.sleep(0.01)
+            executor.submit(get_and_count_connections)
+            time.sleep(0.01)
+            executor.submit(_db_access.add, test_obj)
+            time.sleep(0.02)
+            self.assertEqual(src.pool.checkedin(), 1)
+
+
 if __name__ == "__main__":
+    # runner = unittest.TextTestRunner(verbosity=2)
+    # runner.run(unittest.makeSuite(Test_Waiting_Mechanism_Releases_Connection_To_Pool))
     unittest.main(verbosity=2, buffer=True)  # pragma: no covers

--- a/tests/database/test_wait_for_content.py
+++ b/tests/database/test_wait_for_content.py
@@ -195,6 +195,4 @@ class Test_Waiting_Mechanism_Releases_Connection_To_Pool(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # runner = unittest.TextTestRunner(verbosity=2)
-    # runner.run(unittest.makeSuite(Test_Waiting_Mechanism_Releases_Connection_To_Pool))
     unittest.main(verbosity=2, buffer=True)  # pragma: no covers


### PR DESCRIPTION
Previously, the wait mechanism applied inside a context manager, inside which the query was being sent to the database and thus, it holded the database connection, causing another requests waiting for the same data to create their own connections. This cause problems with exceeding the maximum number of active connections.

The opened connection is however not used by any way when waiting for new data to be sent to the server and so, the connection can be released. This reduces the count of active connections required. 

https://youtrack.bringauto.com/issue/BAF-872/Wait-Mechanismus-holds-DB-connection

Closes BAF-872.