### PR TITLE
Do not check final state when adding default order state

### DIFF
--- a/fleet_management_api/api_impl/controllers/order.py
+++ b/fleet_management_api/api_impl/controllers/order.py
@@ -327,7 +327,7 @@ def _group_new_orders_by_car(orders: list[_models.Order]) -> dict[CarId, list[_m
 
 def _post_default_order_states(order_ids: list[int]) -> _Response:
     order_states = [_models.OrderState(order_id=id_, status=DEFAULT_STATUS) for id_ in order_ids]
-    response = _order_state.create_order_states_from_argument_and_post(order_states)
+    response = _order_state.create_order_states_from_argument_and_post(order_states, check_final_state=False)
     return response
 
 

--- a/fleet_management_api/api_impl/controllers/order_state.py
+++ b/fleet_management_api/api_impl/controllers/order_state.py
@@ -98,6 +98,8 @@ def create_order_states_from_argument_and_post(order_states: list[_models.OrderS
         db_model.car_id = order.car_id
         db_models.append(db_model)
 
+    assert len(db_models) > 0
+
     response = _db_access.add(*db_models)
     if response.status_code == 200:
         try:

--- a/fleet_management_api/database/db_access.py
+++ b/fleet_management_api/database/db_access.py
@@ -112,7 +112,8 @@ def add(
     """
     global _wait_mg
     if not added:
-        return _text_response("Empty request body. Nothing to add to database.")
+        return _json_response([])
+
     _check_common_base_for_all_objs(*added)
     source = _get_current_connection_source(connection_source)
     with _Session(source) as session:


### PR DESCRIPTION
There was a bug in checking if the order's final state (with status CANCELED or DONE) has already been posted. It was checked even when posting the default state of the order. 

This check is turned off for posting default state.