### PR TITLE
Use base docker bringauto/python-environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM python:3.10-alpine
+FROM bringauto/python-environment:latest
 
 WORKDIR /home/bringauto
 
 COPY ./requirements.txt /home/bringauto
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN "$PYTHON_ENVIRONMENT_PYTHON3" -m pip install --no-cache-dir -r requirements.txt
 
-RUN mkdir /home/bringauto/log
 COPY config /home/bringauto/config
 COPY fleet_management_api /home/bringauto/fleet_management_api
 
 EXPOSE 8080
 
-ENTRYPOINT ["python"]
-CMD ["-m", "fleet_management_api", "config/config.json"]
+USER 5000:5000
+RUN mkdir /home/bringauto/log
+
+ENTRYPOINT ["bash", "-c", "$PYTHON_ENVIRONMENT_PYTHON3 -m fleet_management_api $0 $@"]
+CMD ["config/config.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ COPY fleet_management_api /home/bringauto/fleet_management_api
 
 EXPOSE 8080
 
-USER 5000:5000
 RUN mkdir /home/bringauto/log
 
 ENTRYPOINT ["bash", "-c", "$PYTHON_ENVIRONMENT_PYTHON3 -m fleet_management_api $0 $@"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,8 +13,8 @@ services:
       - ./log:/home/bringauto/log/
     networks:
       - api-network
-    entrypoint:
-      ["python", "-m", "fleet_management_api", "config/config.json", "--location", "postgresql-database"]
+    command:
+      ["config/config.json", "--location", "postgresql-database"]
 
   postgresql-database:
     image: postgres:16

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 3.2.0
+  version: 3.2.1
 servers:
 - url: /v2/management
 security:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 3.2.0
+  version: 3.2.1
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "3.2.0"
+version = "3.2.1"
 
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the OpenAPI specification for the BringAuto Fleet Management API to version 3.2.1, ensuring continued compatibility and documentation accuracy.
  
- **Bug Fixes**
	- Adjusted the entry point for the server service in the Docker configuration for improved command execution.

- **Chores**
	- Updated project version from 3.2.0 to 3.2.1 in relevant files, reflecting the latest changes and enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->