### PR TITLE
Baf 991/more logging options in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Python 3.10.12+
 The server settings can be found in the `config/config.json`, including the database logging information and parameters for the database cleanup.
 
 The main parts of the configuration file are the following:
-
-- `logging`. Contains the logging configuration.
+- `logging` - contains the keys `console`and `file` for printing the logs into a console and a file, respectively. The `file` contains field `path` to set the (absolute or relative) path to the directory to store the logs. Both contain the following keys:
+  - `level` - logging level as a string (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Case-insensitive.
+  - `use` - set to `True` to allow to print the logs, otherwise set to `False`.
 - `http_server`. Contains the server's URI and port.
 - `security`. Described [here](#configuring-oauth2).
 - `database`. This contains the database connection configuration and the tables' parameters (e.g., the maximum number of stored records).

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,14 @@
 {
     "logging": {
-        "log-path": "./log/",
-        "verbose": true
+        "console": {
+            "level": "debug",
+            "use": true
+        },
+        "file": {
+            "level": "debug",
+            "use": true,
+            "path": "./log/"
+        }
     },
     "http_server": {
         "base_uri": "http://localhost/v2/management",

--- a/fleet_management_api/__main__.py
+++ b/fleet_management_api/__main__.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     args = _args.request_and_get_script_arguments("Run the Fleet Management v2 HTTP API server.")
 
     try:
-        configure_logging("Fleet Management HTTP API", {"logging": args.config.logging})
+        configure_logging("Fleet Management HTTP API", args.config)
     except Exception as e:
         print(f"Error when configuring logging. {e}")
         exit(1)

--- a/fleet_management_api/logs.py
+++ b/fleet_management_api/logs.py
@@ -3,20 +3,14 @@ import logging.handlers
 import os
 import logging.config
 
-from typing import TypeVar, Mapping
-
-
-T = TypeVar("T", bound=Mapping)
+from .script_args.configs import APIConfig as _APIConfig, Logging as _Logging
 
 
 _DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 LOGGER_NAME = "werkzeug"
 
 
-_log_level_by_verbosity = {False: logging.WARNING, True: logging.DEBUG}
-
-
-def configure_logging(component_name: str, config: dict) -> None:
+def configure_logging(component_name: str, config: _APIConfig) -> None:
     """Configure the logging for the application.
 
     The component name is written in the log messages to identify the source of the log message.
@@ -24,50 +18,54 @@ def configure_logging(component_name: str, config: dict) -> None:
     The logging configuration is read from a JSON file. If the file is not found, a default configuration is used.
     """
     try:
-        log_config = config.get("logging", {})
-        if not log_config:
-            raise ValueError("No logging configuration found")
-        logger = logging.getLogger(LOGGER_NAME)
-        verbose: bool = log_config.get("verbose", None)
-        log_dir_path = log_config.get("log-path", None)
-        if verbose is None:
-            raise ValueError("No verbosity level found in logging configuration")
-        if not os.path.exists(log_dir_path):
-            raise ValueError(f"Log directory does not exist: {log_dir_path}. Check the config file.")
+        log_config = config.logging
 
-        logger.setLevel(_log_level_by_verbosity[verbose])
-
-        # create formatter
-        formatter = logging.Formatter(_log_format(component_name), datefmt=_DATE_FORMAT)
-
-        # file handler
-        log_dir_path = log_config.get("log-path", None)
-        if log_dir_path is None:
-            raise ValueError("No log directory path found in logging configuration")
-        file_path = os.path.join(log_config["log-path"], _log_file_name(component_name) + ".log")
-        file_handler = logging.handlers.RotatingFileHandler(
-            file_path, maxBytes=10485760, backupCount=5
-        )
-        file_handler.setFormatter(formatter)
-        logger.addHandler(file_handler)
-
-        # console handler
-        if verbose:
-            console_handler = logging.StreamHandler()
-            console_handler.setFormatter(formatter)
-            logger.addHandler(console_handler)
-
-        logger.propagate = False
-
-    except PermissionError as pe:
-        logging.error(f"{component_name}: Permission to write into an existing log file denied: {pe}")
-        raise
+        if log_config.console.use:
+            _configure_logging_to_console(log_config.console, component_name)
+        if log_config.file.use:
+            _configure_logging_to_file(log_config.file, component_name)
     except ValueError as ve:
         logging.error(f"{component_name}: Configuration error: {ve}")
         raise
     except Exception as e:
-        logging.error(f"{component_name}: Unexpected error when configuring logging: {e}")
+        logging.error(f"{component_name}: Error when configuring logging: {e}")
         raise
+
+
+def _configure_logging_to_console(config: _Logging.HandlerConfig, component_name: str):
+    """Configure the logging to the console.
+
+    The console logging is configured to use the logging level and format specified in the configuration.
+    """
+    handler = logging.StreamHandler()
+    handler.setLevel(config.level)
+    _add_formatter(handler, component_name)
+    _use_handler(handler)
+
+
+def _configure_logging_to_file(config: _Logging.HandlerConfig, component_name: str) -> None:
+    """Configure the logging to a file.
+
+    The file logging is configured to use the logging level and format specified in the configuration.
+    """
+    if not config.path:
+        raise ValueError(f"Log directory does not exist: {config.path}. Check the config file.")
+    file_path = os.path.join(config.path, _log_file_name(component_name) + ".log")
+    handler = logging.handlers.RotatingFileHandler(file_path, maxBytes=10485760, backupCount=5)
+    handler.setLevel(config.level)
+    _add_formatter(handler, component_name)
+    _use_handler(handler)
+
+
+def _add_formatter(handler: logging.Handler, component_name: str) -> None:
+    """Set the formatter for the logging handler."""
+    formatter = logging.Formatter(_log_format(component_name), datefmt=_DATE_FORMAT)
+    handler.setFormatter(formatter)
+
+
+def _use_handler(handler: logging.Handler) -> None:
+    """Add handler to the logger."""
+    logging.getLogger(LOGGER_NAME).addHandler(handler)
 
 
 def _log_format(component_name: str) -> str:
@@ -77,4 +75,3 @@ def _log_format(component_name: str) -> str:
 
 def _log_file_name(component_name: str) -> str:
     return "_".join(component_name.lower().split())
-

--- a/fleet_management_api/logs.py
+++ b/fleet_management_api/logs.py
@@ -52,7 +52,9 @@ def _configure_logging_to_file(config: _Logging.HandlerConfig, component_name: s
     The file logging is configured to use the logging level and format specified in the configuration.
     """
     if not config.path:
-        raise ValueError(f"Log directory does not exist: {config.path}. Check the config file.")
+        raise ValueError("Log path is not specified in the configuration. Check the config file.")
+    if not os.path.exists(config.path):
+        os.makedirs(config.path, exist_ok=True)
     file_path = os.path.join(config.path, _log_file_name(component_name) + ".log")
     handler = logging.handlers.RotatingFileHandler(file_path, maxBytes=10485760, backupCount=5)
     handler.setLevel(config.level)

--- a/fleet_management_api/logs.py
+++ b/fleet_management_api/logs.py
@@ -24,6 +24,9 @@ def configure_logging(component_name: str, config: _APIConfig) -> None:
             _configure_logging_to_console(log_config.console, component_name)
         if log_config.file.use:
             _configure_logging_to_file(log_config.file, component_name)
+        logging.getLogger(LOGGER_NAME).setLevel(
+            logging.DEBUG
+        )  # This ensures the logging level will be fully determined by the handlers
     except ValueError as ve:
         logging.error(f"{component_name}: Configuration error: {ve}")
         raise

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 3.2.0
+  version: 3.3.0
 servers:
 - url: /v2/management
 security:

--- a/fleet_management_api/script_args/configs.py
+++ b/fleet_management_api/script_args/configs.py
@@ -1,16 +1,34 @@
 from __future__ import annotations
-from typing import Optional, Any
+from typing import Optional, Any, Literal
 
 import pydantic
 
 
+LoggingLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+
+
 class APIConfig(pydantic.BaseModel):
-    logging: dict[str, Any]
+    logging: Logging
     http_server: HTTPServer
     database: Database
     security: Security
     api: API
     data: Data
+
+
+class Logging(pydantic.BaseModel):
+    console: HandlerConfig
+    file: HandlerConfig
+
+    class HandlerConfig(pydantic.BaseModel):
+        level: LoggingLevel
+        use: bool
+        path: str = ""
+
+        @pydantic.field_validator("level", mode="before")
+        @classmethod
+        def validate_command(cls, level: str) -> str:
+            return level.upper()
 
 
 class Data(pydantic.BaseModel):

--- a/fleet_management_api/script_args/configs.py
+++ b/fleet_management_api/script_args/configs.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Any, Literal
+from typing import Optional, Literal
 
 import pydantic
 
@@ -27,7 +27,7 @@ class Logging(pydantic.BaseModel):
 
         @pydantic.field_validator("level", mode="before")
         @classmethod
-        def validate_command(cls, level: str) -> str:
+        def validate_level(cls, level: str) -> str:
             return level.upper()
 
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,96 +1,96 @@
-openapi: 3.0.0
-info:
-  title: BringAuto Fleet Management v2 API
-  description: Specification for BringAuto fleet backend HTTP API
-  version: 3.2.0
-  contact:
-    name: BringAuto s.r.o
-    url: https://bringauto.com
-    email: fleet@bringauto.com
-  license:
-    name: AGPLv3
-    url: https://www.gnu.org/licenses/agpl-3.0.en.html
+  openapi: 3.0.0
+  info:
+    title: BringAuto Fleet Management v2 API
+    description: Specification for BringAuto fleet backend HTTP API
+    version: 3.2.0
+    contact:
+      name: BringAuto s.r.o
+      url: https://bringauto.com
+      email: fleet@bringauto.com
+    license:
+      name: AGPLv3
+      url: https://www.gnu.org/licenses/agpl-3.0.en.html
 
-servers:
-  - url: /v2/management
+  servers:
+    - url: /v2/management
 
-security:
-  - APIKeyAuth: []
-  - oAuth2AuthCode: []
+  security:
+    - APIKeyAuth: []
+    - oAuth2AuthCode: []
 
-tags:
-  - name: api
-    description: API health check
-  - name: car
-    description: Car related functions
-  - name: carState
-    description: Car state-related functions
-  - name: order
-    description: Order-related functions
-  - name: orderState
-    description: Order state-related functions
-  - name: platformHW
-    description: Platform hardware-related functions
-  - name: route
-    description: Route state-related functions
-  - name: stop
-    description: Stop state-related functions
-  - name: security
-    description: Authentication-related functions
+  tags:
+    - name: api
+      description: API health check
+    - name: car
+      description: Car related functions
+    - name: carState
+      description: Car state-related functions
+    - name: order
+      description: Order-related functions
+    - name: orderState
+      description: Order state-related functions
+    - name: platformHW
+      description: Platform hardware-related functions
+    - name: route
+      description: Route state-related functions
+    - name: stop
+      description: Stop state-related functions
+    - name: security
+      description: Authentication-related functions
 
-paths:
-  /apialive:
-    $ref: 'check_api.yaml#/paths/~1apialive'
+  paths:
+    /apialive:
+      $ref: 'check_api.yaml#/paths/~1apialive'
 
-  /car:
-    $ref: 'car.yaml#/paths/~1car'
-  /car/{carId}:
-    $ref: 'car.yaml#/paths/~1car~1{carId}'
-  /carstate:
-    $ref: 'car.yaml#/paths/~1carstate'
-  /carstate/{carId}:
-    $ref: 'car.yaml#/paths/~1carstate~1{carId}'
+    /car:
+      $ref: 'car.yaml#/paths/~1car'
+    /car/{carId}:
+      $ref: 'car.yaml#/paths/~1car~1{carId}'
+    /carstate:
+      $ref: 'car.yaml#/paths/~1carstate'
+    /carstate/{carId}:
+      $ref: 'car.yaml#/paths/~1carstate~1{carId}'
 
-  /order:
-    $ref: 'order.yaml#/paths/~1order'
-  /order/{carId}:
-    $ref: 'order.yaml#/paths/~1order~1{carId}'
-  /order/{carId}/{orderId}:
-    $ref: 'order.yaml#/paths/~1order~1{carId}~1{orderId}'
-  /orderstate:
-    $ref: 'order.yaml#/paths/~1orderstate'
-  /orderstate/{orderId}:
-    $ref: 'order.yaml#/paths/~1orderstate~1{orderId}'
+    /order:
+      $ref: 'order.yaml#/paths/~1order'
+    /order/{carId}:
+      $ref: 'order.yaml#/paths/~1order~1{carId}'
+    /order/{carId}/{orderId}:
+      $ref: 'order.yaml#/paths/~1order~1{carId}~1{orderId}'
+    /orderstate:
+      $ref: 'order.yaml#/paths/~1orderstate'
+    /orderstate/{orderId}:
+      $ref: 'order.yaml#/paths/~1orderstate~1{orderId}'
 
-  /platformhw:
-    $ref: 'platform_hw.yaml#/paths/~1platformhw'
-  /platformhw/{platformHwId}:
-    $ref: 'platform_hw.yaml#/paths/~1platformhw~1{platformHwId}'
+    /platformhw:
+      $ref: 'platform_hw.yaml#/paths/~1platformhw'
+    /platformhw/{platformHwId}:
+      $ref: 'platform_hw.yaml#/paths/~1platformhw~1{platformHwId}'
 
-  /route:
-    $ref: 'route.yaml#/paths/~1route'
-  /route/{routeId}:
-    $ref: 'route.yaml#/paths/~1route~1{routeId}'
-  /route-visualization:
-    $ref: 'route.yaml#/paths/~1route-visualization'
-  /route-visualization/{routeId}:
-    $ref: 'route.yaml#/paths/~1route-visualization~1{routeId}'
+    /route:
+      $ref: 'route.yaml#/paths/~1route'
+    /route/{routeId}:
+      $ref: 'route.yaml#/paths/~1route~1{routeId}'
+    /route-visualization:
+      $ref: 'route.yaml#/paths/~1route-visualization'
+    /route-visualization/{routeId}:
+      $ref: 'route.yaml#/paths/~1route-visualization~1{routeId}'
 
-  /stop:
-    $ref: 'stop.yaml#/paths/~1stop'
-  /stop/{stopId}:
-    $ref: 'stop.yaml#/paths/~1stop~1{stopId}'
+    /stop:
+      $ref: 'stop.yaml#/paths/~1stop'
+    /stop/{stopId}:
+      $ref: 'stop.yaml#/paths/~1stop~1{stopId}'
 
-  /login:
-    $ref: 'security.yaml#/paths/~1login'
-  /token_get:
-    $ref: 'security.yaml#/paths/~1token_get'
-  /token_refresh:
-    $ref: 'security.yaml#/paths/~1token_refresh'
+    /login:
+      $ref: 'security.yaml#/paths/~1login'
+    /token_get:
+      $ref: 'security.yaml#/paths/~1token_get'
+    /token_refresh:
+      $ref: 'security.yaml#/paths/~1token_refresh'
 
-components:
-  securitySchemes:
-    APIKeyAuth:
-      $ref: 'security.yaml#/components/securitySchemes/APIKeyAuth'
-    oAuth2AuthCode:
-      $ref: 'security.yaml#/components/securitySchemes/oAuth2AuthCode'
+  components:
+    securitySchemes:
+      APIKeyAuth:
+        $ref: 'security.yaml#/components/securitySchemes/APIKeyAuth'
+      oAuth2AuthCode:
+        $ref: 'security.yaml#/components/securitySchemes/oAuth2AuthCode'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@
   info:
     title: BringAuto Fleet Management v2 API
     description: Specification for BringAuto fleet backend HTTP API
-    version: 3.2.0
+    version: 3.3.0
     contact:
       name: BringAuto s.r.o
       url: https://bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "3.2.0"
+version = "3.3.0"
 
 
 [tool.setuptools.packages.find]

--- a/tests/_utils/test_config.json
+++ b/tests/_utils/test_config.json
@@ -1,7 +1,14 @@
 {
     "logging": {
-        "log-path": "./log/",
-        "verbose": false
+        "console": {
+            "level": "debug",
+            "use": true
+        },
+        "file": {
+            "level": "debug",
+            "use": true,
+            "path": "./log/"
+        }
     },
     "http_server": {
         "base_uri": "http://localhost/v2/management",

--- a/tests/script_args/test_config.json
+++ b/tests/script_args/test_config.json
@@ -1,7 +1,14 @@
 {
     "logging": {
-        "log-path": "log",
-        "verbose": true
+        "console": {
+            "level": "debug",
+            "use": true
+        },
+        "file": {
+            "level": "debug",
+            "use": true,
+            "path": "./log/"
+        }
     },
     "http_server": {
         "base_uri": "https://someadress.com/",


### PR DESCRIPTION
The previous very simple logging configuration has been considered insufficient for controlling log output. 

The previous structure 
{
   "verbose": <\boolean\>,
   "log_path": \<path\>
}

has been replaced with 

{
        "console": {
            "level": \<level-name\>,
            "use":  \<boolean\>
        },
        "file": {
            "level": \<level-name\>,
            "use":  \<boolean\>,
            "path": \<path\>
        }
 }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Updated OpenAPI specification to version 3.3.0, adding new endpoints for managing cars, orders, and stops.
	- Enhanced logging configuration for improved clarity and control over console and file logging.

- **Documentation**
	- Revised README.md for better clarity on API configuration and logging details.

- **Bug Fixes**
	- Streamlined logging configuration process, improving error handling and readability.

- **Chores**
	- Updated project version to 3.3.0 in relevant files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->