### PR TITLE
Fix oauth bug

### DIFF
--- a/fleet_management_api/api_impl/api_logging.py
+++ b/fleet_management_api/api_impl/api_logging.py
@@ -17,6 +17,11 @@ def log_info(message: str) -> None:
     logger.info(message)
 
 
+def log_debug(message: str) -> None:
+    """Pass a custom debug message to the API logger."""
+    logger.debug(message)
+
+
 def log_error(message: str) -> None:
     """Pass a custom error message to the API logger."""
     logger.error(message)

--- a/fleet_management_api/api_impl/auth_controller.py
+++ b/fleet_management_api/api_impl/auth_controller.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from fleet_management_api.api_impl.security import SecurityObj
 from flask import redirect
-from fleet_management_api.api_impl.api_logging import log_info, log_error
+from fleet_management_api.api_impl.api_logging import log_info, log_error, log_debug
 from fleet_management_api.api_impl.api_responses import (
     Response as _Response,
     error as _error,
@@ -35,8 +35,9 @@ def login() -> _Response:
     """
     try:
         return redirect(_security.get_authentication_url())
-    except:
+    except Exception as e:
         msg = "Problem reaching oAuth service."
+        log_debug(str(e))
         log_error(msg)
         return _error(500, msg, "oAuth service error")
 

--- a/fleet_management_api/api_impl/security.py
+++ b/fleet_management_api/api_impl/security.py
@@ -31,9 +31,7 @@ class SecurityObj:
 
     def get_authentication_url(self) -> str:
         """Get keycloak url used for authentication."""
-        auth_url = self._oid.auth_url(
-            redirect_uri=self._callback, scope=self._scope, state=self._state
-        )
+        auth_url = self._oid.auth_url(redirect_uri=self._callback)
         return auth_url
 
     def token_get(

--- a/fleet_management_api/api_impl/security.py
+++ b/fleet_management_api/api_impl/security.py
@@ -31,7 +31,9 @@ class SecurityObj:
 
     def get_authentication_url(self) -> str:
         """Get keycloak url used for authentication."""
-        auth_url = self._oid.auth_url(redirect_uri=self._callback)
+        auth_url = self._oid.auth_url(
+            redirect_uri=self._callback, state=self._state, scope=self._scope
+        )
         return auth_url
 
     def token_get(

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 3.3.0
+  version: 3.3.1
 servers:
 - url: /v2/management
 security:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@
   info:
     title: BringAuto Fleet Management v2 API
     description: Specification for BringAuto fleet backend HTTP API
-    version: 3.3.0
+    version: 3.3.1
     contact:
       name: BringAuto s.r.o
       url: https://bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "3.3.0"
+version = "3.3.1"
 
 [tool.setuptools.packages.find]
 include = ["fleet_management_api", "openapi", "config"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ setuptools >= 21.0.0
 Flask == 2.1.1
 python-dotenv >= 1.0.0
 psycopg2-binary >= 2.9.9
-python-keycloak == 3.7.0
+python-keycloak == 4.7.0
 keycloak-client == 0.15.4
 pyjwt == 2.3.0
 cryptography == 3.4.8


### PR DESCRIPTION
The fleet management API  showed a following error when calling GET on /login endpoint: 

- KeycloakOpenID.auth_url() got an unexpected keyword argument 'scope'

This is caused by error in the python-keycloak package (v3.7.0) where the argument scope (and state also) is missing in contrast to the package's documentation.

The python-keycloak package version in requirements.txt has been changed to 4.7.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new debug logging function to enhance logging capabilities for better error tracking.

- **Improvements**
	- Updated error handling in authentication processes to provide more context in logs.
	- Rearranged parameters in authentication URL generation for improved clarity.

- **Version Updates**
	- Updated OpenAPI specification and project version from 3.3.0 to 3.3.1, ensuring consistency across documentation and project files.
	- Updated `python-keycloak` package version in dependencies from 3.7.0 to 4.7.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->