### PR TITLE
Fix async client proxies argument error

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -6,7 +6,7 @@
         },
         "file": {
             "level": "debug",
-            "use": true,
+            "use": false,
             "path": "./log/"
         }
     },
@@ -42,8 +42,8 @@
     },
     "data": {
         "orders": {
-            "max_active_orders": 2,
-            "max_inactive_orders": 2
+            "max_active_orders": 10,
+            "max_inactive_orders": 10
         }
     }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -6,7 +6,7 @@
         },
         "file": {
             "level": "debug",
-            "use": false,
+            "use": true,
             "path": "./log/"
         }
     },

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 3.4.0
+  version: 3.4.1
 servers:
 - url: /v2/management
 security:

--- a/log/.gitignore
+++ b/log/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@
   info:
     title: BringAuto Fleet Management v2 API
     description: Specification for BringAuto fleet backend HTTP API
-    version: 3.4.0
+    version: 3.4.1
     contact:
       name: BringAuto s.r.o
       url: https://bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "3.4.0"
+version = "3.4.1"
 
 [tool.setuptools.packages.find]
 include = ["fleet_management_api", "openapi", "config"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.1.1
+httpx == 0.27.2
 python-dotenv >= 1.0.0
 psycopg2-binary >= 2.9.9
 python-keycloak == 4.7.0


### PR DESCRIPTION
Keycloak package internally uses the httpx Python package. This package recently had an update, which has not been addressed by the keycloak package, at least not yet.

I added a line to requirements.txt, setting the httpx version to 0.27.2.

Other minor change is increasing the default maximum number of orders to 10. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased limits for active and inactive orders from 2 to 10, enhancing order management capabilities.
	- Added a new dependency, `httpx == 0.27.2`, to improve networking capabilities.

- **Updates**
	- Updated the OpenAPI specification version from 3.4.0 to 3.4.1, ensuring documentation is up-to-date.
	- Updated project version from 3.4.0 to 3.4.1 in the project configuration.

- **Chores**
	- Removed the `.gitignore` file from the log directory, which may lead to tracking of log files in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->