### PR TITLE
Handle missing last states for car and order

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -15,7 +15,7 @@
         "port": 8081
     },
     "security": {
-        "keycloak_url": "https://keycloak.bringauto.com",
+        "keycloak_url": "https://keycloak.bringauto.com/auth/",
         "client_id": "",
         "client_secret_key": "",
         "scope": "",

--- a/fleet_management_api/api_impl/controllers/car.py
+++ b/fleet_management_api/api_impl/controllers/car.py
@@ -169,23 +169,38 @@ def update_cars() -> _Response:
 
 
 def _get_car_with_last_state(car_db_model: _db_models.CarDBModel) -> _models.Car:
+    last_state = _get_last_car_state(car_db_model)
+    last_action_state = _get_last_car_action_state(car_db_model)
+    car = _obj_to_db.car_from_db_model(car_db_model, last_state, last_action_state)
+    return car
+
+
+def _get_last_car_state(car_db_model: _db_models.CarDBModel) -> _CarState | None:
     db_last_states = _db_access.get(
         _db_models.CarStateDBModel,
         criteria={"car_id": lambda x: x == car_db_model.id},
         sort_result_by={"timestamp": "desc", "id": "desc"},
         first_n=1,
     )
+    if db_last_states:
+        last_state = _obj_to_db.car_state_from_db_model(db_last_states[0])
+    else:
+        last_state = None
+    return last_state
+
+
+def _get_last_car_action_state(car_db_model: _db_models.CarDBModel) -> _CarActionState | None:
     db_last_action_states = _db_access.get(
         _db_models.CarActionStateDBModel,
         criteria={"car_id": lambda x: x == car_db_model.id},
         sort_result_by={"timestamp": "desc", "id": "desc"},
         first_n=1,
     )
-    last_state = _obj_to_db.car_state_from_db_model(db_last_states[0])
-    last_action_state = _obj_to_db.car_action_state_from_db_model(db_last_action_states[0])
-
-    car = _obj_to_db.car_from_db_model(car_db_model, last_state, last_action_state)
-    return car
+    if db_last_action_states:
+        last_action_state = _obj_to_db.car_action_state_from_db_model(db_last_action_states[0])
+    else:
+        last_action_state = None
+    return last_action_state
 
 
 def _post_default_car_state(car_ids: list[int]) -> _Response:

--- a/fleet_management_api/api_impl/controllers/order.py
+++ b/fleet_management_api/api_impl/controllers/order.py
@@ -316,26 +316,14 @@ def get_orders(since: int = 0) -> _Response:
 
 
 def _car_exist(car_id: int) -> bool:
-    return bool(_db_access.exists(_db_models.CarDBModel, {"id": lambda x: x==car_id}))
+    return bool(_db_access.exists(_db_models.CarDBModel, {"id": lambda x: x == car_id}))
 
 
 def _get_order_with_last_state(
     order_db_model: _db_models.OrderDBModel,
 ) -> _models.Order | None:
-    states = _db_access.get(
-        _db_models.OrderStateDBModel,
-        criteria={"order_id": lambda x: x == order_db_model.id},
-        sort_result_by={"timestamp": "desc", "id": "desc"},
-        first_n=1,
-    )
-    if order_db_model.id is None:
-        return None
-    if not states:
-        # The only way no order state exists is the order is in the process of deletion
-        _log_info(f"No order states for order with ID={order_db_model.id}.")
-        return None
-    last_state = _obj_to_db.order_state_from_db_model(states[0])
-    order = _obj_to_db.order_from_db_model(order_db_model, last_state)
+    last_state = _get_last_order_state(order_db_model)
+    order = _obj_to_db.order_from_db_model(order_db_model=order_db_model, last_state=last_state)
     return order
 
 
@@ -346,6 +334,19 @@ def _group_new_orders_by_car(
     for order in orders:
         orders_by_car[order.car_id].append(order)
     return orders_by_car
+
+
+def _get_last_order_state(order_model_db: _db_models.OrderDBModel) -> _models.OrderState | None:
+    db_last_states = _db_access.get(
+        _db_models.OrderStateDBModel,
+        criteria={"order_id": lambda x: x == order_model_db.id},
+        sort_result_by={"timestamp": "desc", "id": "desc"},
+        first_n=1,
+    )
+    if db_last_states:
+        return _obj_to_db.order_state_from_db_model(db_last_states[0])
+    else:
+        return None
 
 
 def _default_order_state(order_id: int) -> _models.OrderState:

--- a/fleet_management_api/api_impl/obj_to_db.py
+++ b/fleet_management_api/api_impl/obj_to_db.py
@@ -17,8 +17,8 @@ def car_to_db_model(car: _models.Car) -> _db_models.CarDBModel:
 
 def car_from_db_model(
     car_db_model: _db_models.CarDBModel,
-    last_state: _models.CarState,
-    last_action_state: _models.CarActionState,
+    last_state: _models.CarState | None,
+    last_action_state: _models.CarActionState | None,
 ) -> _models.Car:
     return _models.Car(
         id=car_db_model.id,

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 3.4.2
+  version: 3.4.3
 servers:
 - url: /v2/management
 security:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@
   info:
     title: BringAuto Fleet Management v2 API
     description: Specification for BringAuto fleet backend HTTP API
-    version: 3.4.2
+    version: 3.4.3
     contact:
       name: BringAuto s.r.o
       url: https://bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "3.4.2"
+version = "3.4.3"
 
 [tool.setuptools.packages.find]
 include = ["fleet_management_api", "openapi", "config"]

--- a/tests/_utils/test_config.json
+++ b/tests/_utils/test_config.json
@@ -15,7 +15,7 @@
         "port": 8080
     },
     "security": {
-        "keycloak_url": "https://keycloak.bringauto.com",
+        "keycloak_url": "https://keycloak.bringauto.com/auth/",
         "client_id": "",
         "client_secret_key": "",
         "scope": "",


### PR DESCRIPTION
The Fleet Management HTTP API did not properly handle cases when some object, e.g. Car remains in the database, but all its states were deleted from the database. 

This problem appeared after update of the Fleet Management HTTP API. When calling GET on /cars/, the API attempted to read the last action state of the car, but at the time of updating the database, the car already existed in the database, but without any car action state (these were added in the updated version of the API).

