### PR TITLE
Baip 316/do not allow api key and jwt simultaneously

### DIFF
--- a/fleet_management_api/api_impl/controller_decorators.py
+++ b/fleet_management_api/api_impl/controller_decorators.py
@@ -63,7 +63,7 @@ def with_processed_request(
             tresponse = _get_accessible_tenants(request, ignore_cookie=ignore_tenant_cookie)
             if tresponse.status_code != 200:
                 return _log_warning_or_error_and_respond(
-                    tresponse.msg, tresponse.status_code, title="No tenants"
+                    tresponse.msg, tresponse.status_code, title="Cannot extract tenants"
                 )
             loaded_request = ProcessedRequest(tresponse.tenants, data=request.data)
             response = controller(loaded_request, *args, **kwargs)

--- a/fleet_management_api/api_impl/tenants.py
+++ b/fleet_management_api/api_impl/tenants.py
@@ -29,6 +29,12 @@ class TenantNotAccessible(Exception):
     pass
 
 
+class MultipleSchemasAtOnce(Exception):
+    """Raise when multiple security schemas are used at the same time."""
+
+    pass
+
+
 class NoAccessibleTenants(Exception):
     """Raise when no accessible tenants are found in a JWT token."""
 
@@ -83,7 +89,7 @@ class AccessibleTenants:
 
         If the current tenant is not empty, only data owned by the current tenant can be read and written to the database.
         """
-
+        self._raise_for_jwt_and_api_key_at_the_same_time(request)
         if "api_key" not in request.query and not key.strip():
             key = get_public_key()
         self._current, self._all_accessible = _extract_current_and_accessible_tenants_from_request(
@@ -120,6 +126,20 @@ class AccessibleTenants:
     def copy(self) -> AccessibleTenants:
         """Return a copy of the current object."""
         return AccessibleTenants.from_dict({"current": self._current, "all": self._all_accessible})
+
+    def _raise_for_jwt_and_api_key_at_the_same_time(self, request: _Request) -> None:
+        """Raise a MultipleSchemasAtOnce exception if both JWT token and API key are provided in the request."""
+        api_key_used = "api_key" in request.query
+        jwt_token_used = _AUTHORIZATION_HEADER_NAME in request.headers and str(
+            request.headers[_AUTHORIZATION_HEADER_NAME]
+        ).startswith("Bearer ")
+
+        if api_key_used and jwt_token_used:
+            # If both API key and JWT token are provided, raise an exception
+            raise MultipleSchemasAtOnce(
+                "Both JWT token and API key are provided in the request. "
+                "Please use either one of them."
+            )
 
 
 class AccessibleTenantsFromDict(AccessibleTenants):
@@ -167,6 +187,13 @@ def get_accessible_tenants(
             msg="Accessible tenants extracted successfully.",
             status_code=200,
             tenants=tenants,
+        )
+    except MultipleSchemasAtOnce as e:
+        # If both JWT token and API key are provided, return an error message
+        return LoadedAccessibleTenants(
+            msg=f"Both JWT token and API key are provided in the request. Error: {str(e)}",
+            status_code=401,
+            tenants=NO_TENANTS,
         )
     except NoAccessibleTenants as e:
         # If the JWT token does not contain any tenants, return an empty tenant object
@@ -225,6 +252,7 @@ def _get_accessible_tenants_from_auth_headers(
     # api key is not provided - read tenants from JWT
     if _AUTHORIZATION_HEADER_NAME not in request.headers:
         raise NoHeaderWithJWTToken
+
     bearer = str(request.headers[_AUTHORIZATION_HEADER_NAME]).split(" ")[-1]
     if not bearer.strip():
         raise Unauthorized("No valid JWT token or API key provided.")

--- a/fleet_management_api/controllers/security_controller.py
+++ b/fleet_management_api/controllers/security_controller.py
@@ -19,6 +19,7 @@ def info_from_oAuth2AuthCode(token):
     :return: Decoded token information or None if token is invalid
     :rtype: dict | None
     """
+
     try:
         decoded_token = jwt.decode(
             token, get_public_key(), algorithms=["RS256"], audience="account"
@@ -60,6 +61,7 @@ def info_from_APIKeyAuth(api_key, *args) -> None | dict:
     :return: Information attached to provided api_key or None if api_key is invalid or does not allow access to called API
     :rtype: dict | None
     """
+
     code, info = _verify_key_and_return_key_info(api_key)
     if code == 200:
         return {"name": info.name}  # type: ignore

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 4.1.1
+  version: 4.1.2
 servers:
 - url: /v2/management
 security:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 4.1.1
+  version: 4.1.2
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "4.1.1"
+version = "4.1.2"
 
 [tool.setuptools.packages.find]
 include = ["fleet_management_api", "openapi", "config"]

--- a/tests/controllers/car/test_car_state_controller.py
+++ b/tests/controllers/car/test_car_state_controller.py
@@ -555,7 +555,7 @@ class Test_Car_States_Without_Tenant_In_Cookies(unittest.TestCase):
             c.set_cookie("", "tenant", "")
             # post to car owned by tenant_A, that is accessible (present in the token)
             response = c.post(
-                "/v2/management/carstate?api_key=test_key",
+                "/v2/management/carstate",
                 headers={"Authorization": f"Bearer {_app.get_token('tenant_A', 'tenant_B')}"},
                 json=[state],
             )

--- a/tests/security/test_combining_auth_schemes.py
+++ b/tests/security/test_combining_auth_schemes.py
@@ -1,0 +1,36 @@
+import unittest
+
+from connexion.exceptions import Unauthorized
+from fleet_management_api.app import get_test_app, get_token
+from fleet_management_api.api_impl.auth_controller import (
+    set_auth_params,
+    generate_test_keys,
+    get_test_public_key,
+)
+import tests._utils.api_test as api_test
+
+
+class Test_Combining_Security_Schemes(api_test.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.app = get_test_app(predef_api_key="test_key")
+        generate_test_keys()
+        set_auth_params(get_test_public_key(strip=True), "test_client")
+
+    def test_passing_jwt_token_and_api_key_simultaneously_yields_401_code(self):
+        with self.app.app.test_client() as c:
+            # Get a JWT token
+            jwt_token = get_token("tenant_1")
+            # Make a request with both the JWT token and API key
+            response = c.get(
+                "/v2/management/car?api_key=test_key",
+                headers={"Authorization": f"Bearer {jwt_token}"},
+            )
+            self.assertEqual(response.status_code, 401)
+            self.assertIn("JWT token", response.json["detail"])
+            self.assertIn("API key", response.json["detail"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
During authentication, the API now checks, if multiple authentication schemes are used in the same request and if so, 401 response is returned.