### PR TITLE
Baf 1095/not null id constraint violated when adding tenant

### DIFF
--- a/fleet_management_api/api_impl/api_logging.py
+++ b/fleet_management_api/api_impl/api_logging.py
@@ -32,7 +32,6 @@ def log_error(message: str) -> None:
     logger.error(str(message))
 
 
-
 def log_warning_or_error_and_respond(msg: str, code: int, title: str) -> _Response:
     """Pass a custom error message to the API logger and return a connexion response with the given code, title and detail."""
     if code < 500:
@@ -45,6 +44,12 @@ def log_warning_or_error_and_respond(msg: str, code: int, title: str) -> _Respon
 def log_warning_and_respond(msg: str, code: int, title: str) -> _Response:
     """Pass a custom warning message to the API logger and return a connexion response with the given code, title and detail."""
     log_warning(msg)
+    return _error(code, str(msg), title)
+
+
+def log_error_and_respond(msg: str, code: int, title: str) -> _Response:
+    """Pass a custom error message to the API logger and return a connexion response with the given code, title and detail."""
+    log_error(msg)
     return _error(code, str(msg), title)
 
 

--- a/fleet_management_api/api_impl/controllers/tenant.py
+++ b/fleet_management_api/api_impl/controllers/tenant.py
@@ -4,6 +4,7 @@ from fleet_management_api.models import Tenant as _Tenant
 from fleet_management_api.api_impl.api_logging import (
     log_info as _log_info,
     log_warning_or_error_and_respond as _log_warning_or_error_and_respond,
+    log_error_and_respond as _log_error_and_respond,
     log_info_and_respond as _log_info_and_respond,
 )
 from fleet_management_api.api_impl.api_responses import (
@@ -58,6 +59,12 @@ def create_tenants(request: _ProcessedRequest, **kwargs) -> _Response:
             _log_info(f"Stop (name='{tenant.name}) has been created.")
         models = [_obj_to_db.tenant_from_db_model(m) for m in posted_db_models]
         return _json_response(models)
+    elif response.status_code == 400 and "null value in column" in response.body["detail"]:
+        return _log_error_and_respond(
+            f"Could not create tenants. {response.body['detail']}",
+            400,
+            title="Not-null constraint violation",
+        )
     else:
         return _log_warning_or_error_and_respond(
             f"Could not create tenants. {response.body['detail']}",

--- a/fleet_management_api/api_impl/controllers/tenant.py
+++ b/fleet_management_api/api_impl/controllers/tenant.py
@@ -50,8 +50,7 @@ def create_tenants(request: _ProcessedRequest, **kwargs) -> _Response:
     """
 
     tenants = [_Tenant.from_dict(t) for t in request.data]
-    tenant_db_models = [_obj_to_db.tenant_to_db_model(t) for t in tenants]
-    response = _db_access.add_without_tenant(*tenant_db_models)
+    response = _db_access.add_tenants(*[t.name for t in tenants])
 
     if response.status_code == 200:
         posted_db_models: list[_db_models.TenantDB] = response.body

--- a/fleet_management_api/api_impl/tenants.py
+++ b/fleet_management_api/api_impl/tenants.py
@@ -134,7 +134,8 @@ class _EmptyTenant(AccessibleTenants):
 
     def __init__(self, *args, **kwargs):
         """The empty tenant object does not have any accessible tenants or a current tenant."""
-        pass
+        self._current = ""
+        self._all_accessible = []
 
     @property
     def current(self) -> str:

--- a/fleet_management_api/database/db_access.py
+++ b/fleet_management_api/database/db_access.py
@@ -159,6 +159,11 @@ def add_tenants(*names: str) -> _Response:
     tenants = [_TenantDB(name=name) for name in names]
     response = add_without_tenant(*tenants)
     if response.status_code == 400 and 'null value in column "id"' in response.body["detail"]:
+        logger.warning(
+            "Server attempted to add tenants without automatically generated IDs."
+            "Attempting to read existing IDs from the database, set tenant IDs before "
+            "adding to database and insert the tenants again."
+        )
         db_tenants = get_tenants(_NO_TENANTS)
         last_id = max([(t.id or 0) for t in db_tenants]) if db_tenants else 0
         for tenant in tenants:

--- a/fleet_management_api/database/db_access.py
+++ b/fleet_management_api/database/db_access.py
@@ -170,8 +170,6 @@ def add_tenants(*names: str) -> _Response:
             last_id += 1
             tenant.id = last_id
         response = add_without_tenant(*tenants, auto_id=False)
-    if response.status_code != 200:
-        raise RuntimeError(f"Error when adding tenants: {response.body}")
     return response
 
 

--- a/fleet_management_api/database/db_models.py
+++ b/fleet_management_api/database/db_models.py
@@ -51,7 +51,7 @@ class SessionWithTenants(Session):
 
 
 class Tenants(Protocol):
-    """Protocol for a class that provides the current tenant and all accessible tmptyenants."""
+    """Protocol for a class that provides the current tenant and all accessible tenants."""
 
     @property
     def current(self) -> str: ...

--- a/fleet_management_api/database/db_models.py
+++ b/fleet_management_api/database/db_models.py
@@ -51,7 +51,7 @@ class SessionWithTenants(Session):
 
 
 class Tenants(Protocol):
-    """Protocol for a class that provides the current tenant and all accessible tenants."""
+    """Protocol for a class that provides the current tenant and all accessible tmptyenants."""
 
     @property
     def current(self) -> str: ...

--- a/fleet_management_api/openapi/openapi.yaml
+++ b/fleet_management_api/openapi/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: BringAuto Fleet Management v2 API
-  version: 4.1.1
+  version: 4.1.2
 servers:
 - url: /v2/management
 security:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: BringAuto Fleet Management v2 API
   description: Specification for BringAuto fleet backend HTTP API
-  version: 4.1.1
+  version: 4.1.2
   contact:
     name: BringAuto s.r.o
     url: https://bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_management_api"
-version = "4.1.1"
+version = "4.1.2"
 
 [tool.setuptools.packages.find]
 include = ["fleet_management_api", "openapi", "config"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ psycopg == 3.2.3
 psycopg-binary == 3.2.3
 psycopg[binary] == 3.2.3
 pydantic == 2.9.2
-SQLAlchemy == 2.0.36
+SQLAlchemy == 2.0.41

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,17 @@
-connexion[swagger-ui] >= 2.6.0, <3
-swagger-ui-bundle >= 0.0.2
-python_dateutil >= 2.6.0
-setuptools >= 21.0.0
+connexion[swagger-ui] == 2.14.2
+swagger-ui-bundle == 0.0.9
+python_dateutil == 2.9.0.post0
+setuptools == 59.6.0
 Flask == 2.1.1
 httpx == 0.27.2
-python-dotenv >= 1.0.0
-psycopg2-binary >= 2.9.9
+python-dotenv == 1.0.1
+psycopg2-binary == 2.9.10
 python-keycloak == 4.7.0
 keycloak-client == 0.15.4
 pyjwt == 2.3.0
 cryptography == 3.4.8
-psycopg >= 3.1.0
-psycopg-binary
-psycopg[binary]
-pydantic >= 2.5.3
-SQLAlchemy >= 2.0.25
+psycopg == 3.2.3
+psycopg-binary == 3.2.3
+psycopg[binary] == 3.2.3
+pydantic == 2.9.2
+SQLAlchemy == 2.0.36

--- a/tests/client/test_client_authorization_and_tenant.py
+++ b/tests/client/test_client_authorization_and_tenant.py
@@ -51,7 +51,7 @@ def wait_for_process(app: TestApp, process: multiprocessing.Process, timeout: fl
         raise RuntimeError("Failed to start test server")
 
 
-class Test_(api_test.TestCase):
+class Test_Authorization(api_test.TestCase):
 
     def setUp(self, *args) -> None:
         super().setUp()

--- a/tests/client/test_client_authorization_and_tenant.py
+++ b/tests/client/test_client_authorization_and_tenant.py
@@ -110,3 +110,38 @@ class Test_(api_test.TestCase):
         self.p.join()
         clear_auth_params()
         clear_test_keys()
+
+
+class Test_PostgreSQL_Database(api_test.TestCase):
+
+    def setUp(self, *args) -> None:
+        super().setUp()
+        generate_test_keys()
+        set_auth_params(get_test_public_key(strip=True), "test_client")
+        self.app = _app.get_test_app(use_previous=True, predef_api_key="APIKey")
+        self.p = multiprocessing.Process(
+            target=self.app.run, kwargs={"port": 8080, "debug": False, "use_reloader": False}
+        )
+        wait_for_process(self.app, self.p)
+
+    def test_using_correct_api_key_and_specifying_tenant_cookie_allows_to_post_and_read_data(
+        self,
+    ):
+        client = ApiClient(
+            configuration=Configuration(
+                host="http://localhost:8080/v2/management",
+                api_key={"APIKeyAuth": "APIKey"},  # api key
+            ),
+            cookie="tenant=test-tenant",
+        )
+        platform_hw_api = PlatformHWApi(client)
+        platform_hw_api.create_hws(platform_hw=[PlatformHWFor(name="test_hw")])
+        tenant_api = TenantApi(client)
+        self.assertEqual([hw.name for hw in platform_hw_api.get_hws()], ["test_hw"])
+        self.assertEqual([t.name for t in tenant_api.get_tenants()], ["test-tenant"])
+
+    def tearDown(self) -> None:
+        self.p.terminate()
+        self.p.join()
+        clear_auth_params()
+        clear_test_keys()

--- a/tests/client/test_client_authorization_and_tenant.py
+++ b/tests/client/test_client_authorization_and_tenant.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import time
+import unittest
 
 import fleet_management_api.app as _app
 from fleet_management_api.api_impl.auth_controller import (
@@ -112,36 +113,5 @@ class Test_(api_test.TestCase):
         clear_test_keys()
 
 
-class Test_PostgreSQL_Database(api_test.TestCase):
-
-    def setUp(self, *args) -> None:
-        super().setUp()
-        generate_test_keys()
-        set_auth_params(get_test_public_key(strip=True), "test_client")
-        self.app = _app.get_test_app(use_previous=True, predef_api_key="APIKey")
-        self.p = multiprocessing.Process(
-            target=self.app.run, kwargs={"port": 8080, "debug": False, "use_reloader": False}
-        )
-        wait_for_process(self.app, self.p)
-
-    def test_using_correct_api_key_and_specifying_tenant_cookie_allows_to_post_and_read_data(
-        self,
-    ):
-        client = ApiClient(
-            configuration=Configuration(
-                host="http://localhost:8080/v2/management",
-                api_key={"APIKeyAuth": "APIKey"},  # api key
-            ),
-            cookie="tenant=test-tenant",
-        )
-        platform_hw_api = PlatformHWApi(client)
-        platform_hw_api.create_hws(platform_hw=[PlatformHWFor(name="test_hw")])
-        tenant_api = TenantApi(client)
-        self.assertEqual([hw.name for hw in platform_hw_api.get_hws()], ["test_hw"])
-        self.assertEqual([t.name for t in tenant_api.get_tenants()], ["test-tenant"])
-
-    def tearDown(self) -> None:
-        self.p.terminate()
-        self.p.join()
-        clear_auth_params()
-        clear_test_keys()
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()  # pragma: no cover

--- a/tests/database/test_postgres_db.py
+++ b/tests/database/test_postgres_db.py
@@ -148,6 +148,27 @@ class Test_Adding_Multiple_Tenants(unittest.TestCase):
             self.assertEqual(response.json[0]["name"], "test_tenant_2")
             self.assertEqual(response.json[0]["id"], 2)
 
+    def test_multiple_requests_with_repeating_tenant_names_always_add_each_tenant_only_once(self):
+        names = ["tenant1", "tenant2", "tenant3"]
+        repeated_names = [
+            names[0],
+            names[1],
+            names[0],
+            names[0],
+            names[2],
+            names[2],
+            names[1],
+            names[1],
+        ]
+        for name in repeated_names:
+            with self.app.app.test_client() as c:
+                response = c.post("/v2/management/tenant?api_key=abcde123", json=[{"name": name}])
+        with self.app.app.test_client() as c:
+            response = c.get("/v2/management/tenant?api_key=abcde123")
+            assert response.json is not None
+            self.assertEqual(len(response.json), len(names))
+            self.assertEqual([tenant["name"] for tenant in response.json], names)
+
     def tearDown(self) -> None:
         self.p.terminate()
         try:

--- a/tests/database/test_postgres_db.py
+++ b/tests/database/test_postgres_db.py
@@ -1,6 +1,7 @@
 import unittest
 import subprocess
 import time
+import multiprocessing
 
 import psycopg2  # type: ignore
 from psycopg2 import OperationalError
@@ -8,6 +9,8 @@ from psycopg2 import OperationalError
 import fleet_management_api.database.connection as _connection
 import fleet_management_api.database.db_access as _db_access
 import fleet_management_api.database.db_models as _db_models
+from fleet_management_api.app import get_app
+
 from tests._utils.constants import TEST_TENANT_NAME
 from tests._utils.setup_utils import TenantFromTokenMock
 
@@ -106,6 +109,47 @@ class Test_Database_Cleanup(unittest.TestCase):
         self.assertFalse(response)
 
     def tearDown(self) -> None:
+        try:
+            subprocess.run(
+                ["docker", "compose", "-f", DOCKER_COMPOSE_FILE_PATH, "down"],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"Error stopping database: {e}")
+
+
+class Test_Adding_Multiple_Tenants(unittest.TestCase):
+    def setUp(self):
+        restart_database()
+        _connection.set_connection_source("localhost", 5432, "test_db", "postgres", PASSWORD)
+        api_key = _db_models.ApiKeyDB(creation_timestamp=0, name="test_key", key="abcde123")
+        _db_access.add_without_tenant(api_key)
+        self.app = get_app()
+        self.p = multiprocessing.Process(
+            target=self.app.run, kwargs={"port": 8080, "debug": False, "use_reloader": False}
+        )
+        self.p.start()
+
+    def test_adding_multiple_tenants_with_non_colliding_names_yield_200_responses(self):
+        with self.app.app.test_client() as c:
+            response = c.post(
+                "/v2/management/tenant?api_key=abcde123", json=[{"name": "test_tenant"}]
+            )
+            self.assertEqual(response.status_code, 200)
+            assert response.json is not None
+            self.assertEqual(response.json[0]["name"], "test_tenant")
+            self.assertEqual(response.json[0]["id"], 1)
+
+            response = c.post(
+                "/v2/management/tenant?api_key=abcde123", json=[{"name": "test_tenant_2"}]
+            )
+            self.assertEqual(response.status_code, 200)
+            assert response.json is not None
+            self.assertEqual(response.json[0]["name"], "test_tenant_2")
+            self.assertEqual(response.json[0]["id"], 2)
+
+    def tearDown(self) -> None:
+        self.p.terminate()
         try:
             subprocess.run(
                 ["docker", "compose", "-f", DOCKER_COMPOSE_FILE_PATH, "down"],

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
 coverage>=2.17
-fleet_management_http_client_python @ git+https://github.com/bringauto/fleet-management-http-client-python.git@test-tenants
+fleet_management_http_client_python @ git+https://github.com/bringauto/fleet-management-http-client-python.git


### PR DESCRIPTION
The "tenants" table on the fleet-protocol-dev  for some reason was missing primary key constraint. This has been added to it. 

In the code itself, the create_tenants function now uses add_tenant function to add tenant to the database.
If the add_tenant now receives error about tenant ID not being automatically set, it reads tenant IDs from db and sets the new tenant ID "manually". 

Create_tenants function now logs error if the not-null constrain violated occurs.

Tests for adding tenants with identical names repeatedly have been added to test the behavior when multiple requests cause the 400 response from the server. 

Closes [BAF-1095](https://youtrack.bringauto.com/issue/BAF-1095/Fleet-Management-HTTP-server-attempts-to-add-Tenant-to-database-with-empty-ID
)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for tenant creation, including specific responses for not-null constraint violations and unique name conflicts.
  - Enhanced database logic to recover from certain tenant creation errors and ensure correct tenant ID assignment.

- **New Features**
  - Added comprehensive tests for tenant creation scenarios, including duplicate and multiple tenant additions.

- **Chores**
  - Updated project and API version to 4.1.2.
  - Pinned all dependencies to exact versions for improved reliability.
  - Adjusted test dependencies to use the default branch.

- **Tests**
  - Expanded test coverage for tenant creation and authorization logic.
  - Improved test class naming and structure for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->